### PR TITLE
Add travis setup to build documentation during PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+- 3.6
+
+cache: pip
+
+install:
+  - pip install -r dev-requirements.txt
+
+script:
+  # Build documentation
+  - pushd docs && make html && popd

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
This asks travis to build the documentation as part of a PR so we can see if it works before merging.