### PR TITLE
Support testing on Travis CI + Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -f environment.yml
+  - conda create -f environment.yml --name earth-analytics-python
   - source activate earth-analytics-python
   - python setup.py install
   - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - pytest --cov=./
+  - pytest --cov=earthpy
   # Build documentation
   - pushd docs && make html && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -f environment.yml --name earth-analytics-python
+  - conda env create -f environment.yml
   - source activate earth-analytics-python
   - python setup.py install
   - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,22 @@ python:
 cache: pip
 
 install:
+  - sudo apt-get update
+  # https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - conda create -q -f environment.yml
+  - source activate earth-analytics-python
+  - python setup.py install
   - pip install -r dev-requirements.txt
 
 script:
+  - pytest
   # Build documentation
   - pushd docs && make html && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ script:
   - pytest --cov=earthpy
   # Build documentation
   - pushd docs && make html && popd
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - pytest
+  - pytest --cov=./
   # Build documentation
   - pushd docs && make html && popd

--- a/README.md
+++ b/README.md
@@ -23,14 +23,10 @@ Then import it into python.
 
 ## Contributors
 
-This package was originally developed by Chris Holdgraf.
-Contributors:
-
-- Carson Farmer
-
-Contributing Breakers:
-
+- Chris Holdgraf
 - Leah Wasser
+- Carson Farmer
+- Max Joseph
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,4 @@ Contributing Breakers:
 ## Testing
 
 This package uses [pytest](https://pytest.org/) for tests.
-To run tests locally, you can exectute the command `pytest`.
-Tests will also be run on Travis CI, and upon a successful build test coverage
-information will be uploaded to Codecov.
+To run tests locally, execute the command `pytest` from the command line.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![DOI](https://zenodo.org/badge/122149160.svg)](https://zenodo.org/badge/latestdoi/122149160)
 [![Build Status](https://travis-ci.com/mbjoseph/earthpy.svg?branch=master)](https://travis-ci.com/mbjoseph/earthpy)
+[![codecov](https://codecov.io/gh/mbjoseph/earthpy/branch/master/graph/badge.svg)](https://codecov.io/gh/mbjoseph/earthpy)
 [![Docs build](https://readthedocs.org/projects/earthpy/badge/?version=latest)](https://earthpy.readthedocs.io/en/latest/?badge=latest)
 
 # Earth Py
@@ -30,3 +31,10 @@ Contributors:
 Contributing Breakers:
 
 - Leah Wasser
+
+## Testing
+
+This package uses [pytest](https://pytest.org/) for tests.
+To run tests locally, you can exectute the command `pytest`.
+Tests will also be run on Travis CI, and upon a successful build test coverage
+information will be uploaded to Codecov.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![DOI](https://zenodo.org/badge/122149160.svg)](https://zenodo.org/badge/latestdoi/122149160)
+[![Build Status](https://travis-ci.com/mbjoseph/earthpy.svg?branch=master)](https://travis-ci.com/mbjoseph/earthpy)
 [![Docs build](https://readthedocs.org/projects/earthpy/badge/?version=latest)](https://earthpy.readthedocs.io/en/latest/?badge=latest)
 
 # Earth Py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![DOI](https://zenodo.org/badge/122149160.svg)](https://zenodo.org/badge/latestdoi/122149160)
-[![Build Status](https://travis-ci.com/mbjoseph/earthpy.svg?branch=master)](https://travis-ci.com/mbjoseph/earthpy)
-[![codecov](https://codecov.io/gh/mbjoseph/earthpy/branch/master/graph/badge.svg)](https://codecov.io/gh/mbjoseph/earthpy)
+[![Build Status](https://travis-ci.com/earthlab/earthpy.svg?branch=master)](https://travis-ci.com/earthlab/earthpy)
+[![codecov](https://codecov.io/gh/earthlab/earthpy/branch/master/graph/badge.svg)](https://codecov.io/gh/earthlab/earthpy)
 [![Docs build](https://readthedocs.org/projects/earthpy/badge/?version=latest)](https://earthpy.readthedocs.io/en/latest/?badge=latest)
 
 # Earth Py

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -1,5 +1,6 @@
 from earthpy import spatial
 
+
 def test_extent_to_json():
     '''Check that a polygon is generated with 5 vertices'''
     json = spatial.extent_to_json(minx=0, miny=0, maxx=1, maxy=1)

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -1,4 +1,3 @@
-import pytest
 from earthpy import spatial
 
 def test_extent_to_json():

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -2,7 +2,7 @@ from earthpy import spatial
 
 
 def test_extent_to_json():
-    '''Check that a polygon is generated with 5 vertices'''
+    """Check that a polygon is generated with 5 vertices."""
     json = spatial.extent_to_json(minx=0, miny=0, maxx=1, maxy=1)
     assert json.get('type') == 'Polygon'
 

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -1,0 +1,10 @@
+import pytest
+from earthpy import spatial
+
+def test_extent_to_json():
+    '''Check that a polygon is generated with 5 vertices'''
+    json = spatial.extent_to_json(minx=0, miny=0, maxx=1, maxy=1)
+    assert json.get('type') == 'Polygon'
+
+    vertices = json.get('coordinates')[0]
+    assert len(vertices) == 5

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,13 @@ channels:
   - conda-forge
 dependencies:
   # Core scientific python
+  - codecov
   - numpy
   - matplotlib
   - python=3.6
   - pyqt
   - pytest
+  - pytest-cov
   - seaborn
 
   # Geo stuff

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - matplotlib
   - python=3.6
   - pyqt
+  - pytest
   - seaborn
 
   # Geo stuff
@@ -25,7 +26,7 @@ dependencies:
 
 #text mining
   - tweepy
-  - nltk 
+  - nltk
 
   # Jupyter Environment
   - notebook
@@ -44,4 +45,3 @@ dependencies:
       - tqdm
       - kiwisolver
       - git+https://github.com/geopandas/geopandas.git
-


### PR DESCRIPTION
Ok @lwasser! This PR adds support for testing the earthpy package on Travis CI, and uploads code coverage reports onto Codecov upon successful builds. 

Tests are contained in the `earthpy/tests/` directory, and for starters I've added just one test to get going. To run these tests locally, you can run `pytest` from the command line (the `environment.yml` file has been updated to install the pytest package, so you may need to update your environment). I spent a fair bit of time comparing testing frameworks, and pytest seems to be one of the better ones (simple to use but powerful when you need it to be).

