### PR TITLE
Adding unit tests for extent_to_json

### DIFF
--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -13,6 +13,7 @@ from shapely.geometry import mapping, box
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from skimage import exposure
 
+
 def extent_to_json(ext_obj):
     """Convert bounds to a shapely geojson like spatial object.
     Helper function
@@ -30,13 +31,14 @@ def extent_to_json(ext_obj):
     """
 
     if type(ext_obj) == gpd.geodataframe.GeoDataFrame:
-        extent_json = mapping(box(*ext_obj.bounds.values[0]))
+        extent_json = mapping(box(*ext_obj.total_bounds))
     elif type(ext_obj) == list:
-        extent_json = mapping(box(ext_obj))
+        extent_json = mapping(box(*ext_obj))
     else:
-        raise ValueError("Please provide a geodataframe of a list of values - minx, miny, maxx, maxy")
+        raise ValueError("Please provide a geodataframe of a list of values.")
 
     return extent_json
+
 
 # calculate normalized difference between two arrays
 # both arrays must be of the same size

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -1,6 +1,32 @@
-from earthpy import spatial
+import earthpy.spatial as es
+from shapely.geometry import Polygon, Point
+import geopandas as gpd
+import pandas as pd
+import pytest
 
 
-def test_dummy():
-    """"Dummy test that will pass."""
-    assert 1 == 1
+def test_extent_to_json():
+    """"Unit tests for extent_to_json()."""
+    # giving a list [minx, miny, maxx, maxy] makes a polygon
+    list_out = es.extent_to_json([0, 0, 1, 1])
+    assert list_out['type'] == 'Polygon'
+
+    # the polygon is the unit square
+    list_poly = Polygon(list_out['coordinates'][0])
+    assert list_poly.area == 1
+    assert list_poly.length == 4
+
+    # providing a GeoDataFrame creates identical output
+    df = pd.DataFrame(
+        {'lat': [0, 1],
+         'lon': [0, 1]}
+    )
+    df['coords'] = list(zip(df.lon, df.lat))
+    df['coords'] = df['coords'].apply(Point)
+    gdf = gpd.GeoDataFrame(df, geometry='coords')
+    gdf_out = es.extent_to_json(gdf)
+    assert gdf_out == list_out
+
+    # giving non-list or GeoDataFrame input raises a ValueError
+    with pytest.raises(ValueError):
+        es.extent_to_json({'a': 'dict'})


### PR DESCRIPTION
This adds unit tests for `extent_to_json` to verify that it can create
extent JSON using both list and GeoDataFrame inputs, and that these
extent outputs are the same regardless of input type. I have also fixed
an error in the implementation of the list-based method (the elements of
the list needed to be unpacked with a `*` in order to act as positional
arguments to the `box` function.

The unit tests also include a check to ensure that a `ValueError` is
raised when we provide input that is neither a list nor a GeoDataFrame
(notice the use of the `pytest.raises` as a context manager).

Should solve https://github.com/earthlab/earthpy/issues/39

@lwasser have a look and see what you think!