### PR TITLE
Clarify module descriptions in rst AND delete unused file path checks, context managers, and input type checks in spatial.py

### DIFF
--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -9,17 +9,19 @@ Earthpy Modules
 ---------------
 
 - Spatial: Various functions for loading, manipulating, and displaying raster data
-  - `create_raster_stack`: generates a single multi-band raster from separate raster TIFs,
+  - ``create_raster_stack``: generates a single multi-band raster from separate raster TIFs,
   such as a collection of single-band TIFs from Landsat
-  - `normalized_diff`: calculate a normalized difference for two bands of a multi-band raster
-  - `hillshade`: create a hillshade array from image elevation data
-  - `crop_image`: crop raster data to a polygon
-  - Custom plotting shortcuts, such as `colorbar` for appropriately sized legends, `create_legend` for
-  legends showing a color for each class of a raster, `plot_bands` for creating a grid of images
-  showing each individual band of a raster, and `plot_rgb` for quickly generating
+  - ``normalized_diff``: calculate a normalized difference for two bands of a multi-band raster
+  - ``hillshade``: create a hillshade array from image elevation data
+  - ``crop_image``: crop raster data to a polygon
+  - Custom plotting shortcuts, such as ``colorbar`` for appropriately sized legends, ``create_legend`` for
+  legends showing a color for each class of a raster, ``plot_bands`` for creating a grid of images
+  showing each individual band of a raster, and ``plot_rgb`` for quickly generating
   composite images or false color images from raster bands.
+
 - IO: Handles data search and retrieval from EarthLab, supporting analytics courses
-available here: https://www.earthdatascience.org/courses/
+  available `here <https://www.earthdatascience.org/courses/>`_.
+
 - Utils: Handles path fixes for EarthLab image retrieval -- new utils module forthcoming
 
 Installation

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -8,9 +8,19 @@ lab earth analytics courses.
 Earthpy Modules
 ---------------
 
-Spatial
-IO
-Utils
+- Spatial: Various functions for loading, manipulating, and displaying raster data
+  - `create_raster_stack`: generates a single multi-band raster from separate raster TIFs,
+  such as a collection of single-band TIFs from Landsat
+  - `normalized_diff`: calculate a normalized difference for two bands of a multi-band raster
+  - `hillshade`: create a hillshade array from image elevation data
+  - `crop_image`: crop raster data to a polygon
+  - Custom plotting shortcuts, such as `colorbar` for appropriately sized legends, `create_legend` for
+  legends showing a color for each class of a raster, `plot_bands` for creating a grid of images
+  showing each individual band of a raster, and `plot_rgb` for quickly generating
+  composite images or false color images from raster bands.
+- IO: Handles data search and retrieval from EarthLab, supporting analytics courses
+available here: https://www.earthdatascience.org/courses/
+- Utils: Handles path fixes for EarthLab image retrieval -- new utils module forthcoming
 
 Installation
 ------------

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -120,9 +120,6 @@ def stack(sources, dest):
     dest : a rio.open writable object that will store raster data.
     """
 
-    #if not os.path.exists(os.path.dirname(dest)):
-    #    raise ValueError("The output directory path that you provided does not exist")
-
     if not type(sources[0]) == rio.io.DatasetReader:
         raise ValueError("The sources object should be of type: rasterio.DatasetReader")
 
@@ -161,16 +158,11 @@ def crop_image(raster, geoms, all_touched = True):
         Specifically the extent (shape elements) and transform properties are updated.
     """
 
-    # test that you have a list of a geodataframe
-    #if not type(geoms) == list:
-    #    raise ValueError("The geoms element used to crop the raster needs to be of type: list. If it is of type dictionary, you can simpy add [object-name-here] to turn it into a list.")
-
     if type(geoms) == gpd.geodataframe.GeoDataFrame:
         clip_ext = [extent_to_json(geoms)]
     else:
         clip_ext = geoms
     # Mask the input image and update the metadata
-    #with rio.open(path) as src:
     out_image, out_transform = rio.mask.mask(raster, clip_ext, crop = True, all_touched = all_touched)
     out_meta = raster.meta.copy()
     out_meta.update({"driver": "GTiff",


### PR DESCRIPTION
This pull request addresses issue #67 

Unused unit tests and commented code lines are deleted from spatial.py
The file get-started.rst now includes descriptions of each of the three modules and converts them to list form.