### PR TITLE
Reword content in spatial-raster.rst and Add summary description of earthpy to index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,19 +5,25 @@
 
 Welcome to Earthpy's documentation!
 ===================================
+Earthpy's documentation contains one Element and two Options.
+  - Element: toctree
+  - Options: maxdepth, caption
+The element and options are applied to the following documents:
+    1. get-started
+    2. spatial-raster
+    3. spatial-vector
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
+.. Element and Options applied to the following documents
    get-started
    spatial-raster
    spatial-vector
 
-
-
-Indices and tables
-==================
+Python indices and tables
+=========================
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ The element and options are applied to the following documents:
   2. spatial-raster
   3. spatial-vector
 
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,10 +5,19 @@
 
 Welcome to Earthpy's documentation!
 ===================================
-Earthpy is a python package devoted to working with spatial and remote sensing data.
 
-Earthpy's Index (Table of Contents)
-===================================
+Earthpy: A Python Package for Earth Data
+========================================
+Earthpy is a python package that makes it easier to plot and work with spatial
+raster and vector data using open source tools. Earthpy depends upon `geopandas`
+which has a focus on vector data and `rasterio` with facilitates input and
+output of raster data files. It also requires `matplotlib` for plotting operations.
+
+Earthpy's goal is to make working with spatial data easier for scientists.
+Contributions to earthpy are welcome.
+
+Earthpy's User Guide
+====================
 
 .. toctree::
    :maxdepth: 2
@@ -24,26 +33,3 @@ Indices and Tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-About Earthpy's Documents
-===================
-
-Get-Started Document
---------------------
-The ``get-started`` document provides a description of Earthpy's modules, the installation process, and dependencies.
-Earthpy's Modules: 
- * Spatial
- * IO
- * Utils
- 
-Spatial-Raster Document
------------------------
-The ``spatial-raster`` document describes earthpy's spatial module, its functions, and provides an example code of how a function handles raster data in Python.
-The specific example in the document highlights the ``stack_raster_tifs`` function, which was created to stack raster files (such as Landsat imagery). 
-
-Spatial-Vector Document
------------------------
-The ``spatial-vector`` document describes earthpy's spatial module, its functions, and provides an example code of how a function handles vector data in Python.
-The specific example in the document highlights the ``clip_shp`` function, which was created to take two GeoDataframe objects, spatially clip the first object, and use the second object as the spatial extent (clip extent).
-
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@
 
 Welcome to Earthpy's documentation!
 ===================================
------------------------------------
+
 Earthpy's documentation contains one Element and two Options.
   - Element: toctree
   - Options: maxdepth, caption

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@
 
 Welcome to Earthpy's documentation!
 ===================================
-
+-----------------------------------
 Earthpy's documentation contains one Element and two Options.
   - Element: toctree
   - Options: maxdepth, caption

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,8 @@
 Welcome to Earthpy's documentation!
 ===================================
 Earthpy's documentation contains one Element and two Options.
-  - Element: toctree
-  - Options: maxdepth, caption
+  - Element: `toctree`
+  - Options: `maxdepth`, `caption`
 The element and options are applied to the following documents:
     1. get-started
     2. spatial-raster
@@ -17,7 +17,6 @@ The element and options are applied to the following documents:
    :maxdepth: 2
    :caption: Contents:
 
-.. Element and Options applied to the following documents
    get-started
    spatial-raster
    spatial-vector

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@
 
 Welcome to Earthpy's documentation!
 ===================================
+
 Earthpy's documentation contains one Element and two Options.
   - Element: toctree
   - Options: maxdepth, caption

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,9 +32,9 @@ Get-Started Document
 --------------------
 The ``get-started`` document provides a description of Earthpy's modules, the installation process, and dependencies.
 Earthpy's Modules: 
-- Spatial
-- IO
-- Utils
+ * Spatial
+ * IO
+ * Utils
  
 Spatial-Raster Document
 -----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,14 +6,14 @@
 Welcome to Earthpy's documentation!
 ===================================
 Earthpy's documentation contains one Element and two Options.
-  - Element: `toctree`
-  - Options: `maxdepth`, `caption`
+  - Element: toctree
+  - Options: maxdepth, caption
 Tables of Contents are inserted with a maximum depth of two, and a caption
-called "Contents".  
+called *Contents*.
 The element and options are applied to the following documents:
-    1. get-started
-    2. spatial-raster
-    3. spatial-vector
+  1. get-started
+  2. spatial-raster
+  3. spatial-vector
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,17 +5,10 @@
 
 Welcome to Earthpy's documentation!
 ===================================
+Earthpy is a python package devoted to working with spatial and remote sensing data.
 
-Earthpy's documentation contains one Element and two Options.
-  - Element: toctree
-  - Options: maxdepth, caption
-Tables of Contents are inserted with a maximum depth of two, and a caption
-called *Contents*.
-The element and options are applied to the following documents:
-  1. get-started
-  2. spatial-raster
-  3. spatial-vector
-
+Earthpy's Index (Table of Contents)
+===================================
 
 .. toctree::
    :maxdepth: 2
@@ -25,9 +18,32 @@ The element and options are applied to the following documents:
    spatial-raster
    spatial-vector
 
-Python indices and tables
-=========================
+Indices and Tables
+==================
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+About Earthpy's Documents
+===================
+
+Get-Started Document
+--------------------
+The ``get-started`` document provides a description of Earthpy's modules, the installation process, and dependencies.
+Earthpy's Modules: 
+- Spatial
+- IO
+- Utils
+ 
+Spatial-Raster Document
+-----------------------
+The ``spatial-raster`` document describes earthpy's spatial module, its functions, and provides an example code of how a function handles raster data in Python.
+The specific example in the document highlights the ``stack_raster_tifs`` function, which was created to stack raster files (such as Landsat imagery). 
+
+Spatial-Vector Document
+-----------------------
+The ``spatial-vector`` document describes earthpy's spatial module, its functions, and provides an example code of how a function handles vector data in Python.
+The specific example in the document highlights the ``clip_shp`` function, which was created to take two GeoDataframe objects, spatially clip the first object, and use the second object as the spatial extent (clip extent).
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,8 @@ Welcome to Earthpy's documentation!
 Earthpy's documentation contains one Element and two Options.
   - Element: `toctree`
   - Options: `maxdepth`, `caption`
+Tables of Contents are inserted with a maximum depth of two, and a caption
+called "Contents".  
 The element and options are applied to the following documents:
     1. get-started
     2. spatial-raster

--- a/docs/spatial-raster.rst
+++ b/docs/spatial-raster.rst
@@ -6,10 +6,9 @@ The ``earthpy`` spatial module provides functions that wrap around the
 
 Stack Raster Files
 ~~~~~~~~~~~~~~~~~~
-
 The ``stack_raster_tifs`` function turns a list of raster paths into:
-  1. a stacked geotiff on your hard drive and
-  2. (optional) an output raster stack in numpy format with associated metadata.
+1. a stacked geotiff on your hard drive and
+2. (optional) an output raster stack in numpy format with associated metadata.
 
 All files in the list must be in the same Coordinate Reference System (CRS) and
 must have the same spatial extent for this to work properly.

--- a/docs/spatial-raster.rst
+++ b/docs/spatial-raster.rst
@@ -7,11 +7,11 @@ and ``geopandas`` to work with raster and vector data in Python.
 Stack Raster Files
 ~~~~~~~~~~~~~~~~~~
 
-The ``stack_raster_tifs`` function takes a list of raster paths and turns that list
-into an
+The ``stack_raster_tifs`` function takes a list of raster paths and turns the list
+into the following:
 
-1. a stacked geotiff on your hard drive and
-2. (optionally) an output raster stack in numpy format with associated metadata.
+1. a stacked geotiff on your local hard drive and
+2. (optional) an output raster stack in numpy format with associated metadata.
 
 All files in the list must be in the same Coordinate Reference System (CRS) and
 must have the same spatial extent for this to work properly.

--- a/docs/spatial-raster.rst
+++ b/docs/spatial-raster.rst
@@ -13,7 +13,7 @@ into an
 1. a stacked geotiff on your hard drive and
 2. (optionally) an output raster stack in numpy format with associated metadata.
 
-All files in the list must be in the same Coordinate Refenence System (CRS) and
+All files in the list must be in the same Coordinate Reference System (CRS) and
 must have the same spatial extent for this to work properly.
 
 ``stack_raster_tifs`` takes 2 input parameters:

--- a/docs/spatial-raster.rst
+++ b/docs/spatial-raster.rst
@@ -1,17 +1,15 @@
 Earthpy Spatial Raster Data
 ===========================
 
-The ``earthpy`` spatial module provides functions that wrap around the ``rasterio``
-and ``geopandas`` to work with raster and vector data in Python.
+The ``earthpy`` spatial module provides functions that wrap around the
+``rasterio`` and ``geopandas`` to work with raster and vector data in Python.
 
 Stack Raster Files
 ~~~~~~~~~~~~~~~~~~
 
-The ``stack_raster_tifs`` function takes a list of raster paths and turns the list
-into the following:
-
-1. a stacked geotiff on your local hard drive and
-2. (optional) an output raster stack in numpy format with associated metadata.
+The ``stack_raster_tifs`` function turns a list of raster paths into:
+  1. a stacked geotiff on your hard drive and
+  2. (optional) an output raster stack in numpy format with associated metadata.
 
 All files in the list must be in the same Coordinate Reference System (CRS) and
 must have the same spatial extent for this to work properly.
@@ -33,7 +31,8 @@ The stack_raster_tiffs function returns the following if ``arr_out=True``:
 
 ``arr``: a numpy array containing all of the stacked data
 
-``meta``: dictionary - the updated metadata for the numpy array in rasterio metadata dictionary format
+``meta``: dictionary - the updated metadata for the numpy array in rasterio
+metadata dictionary format
 
 Example:
 


### PR DESCRIPTION
####  Issue #61 @jlpalomino 
#### Made the following changes:
Reworded spatial-raster.rst lines 9-11:
```
     The ``stack_raster_tifs`` function turns a list of raster paths into:
     1. a stacked geotiff on your hard drive and
     2. (optional) an output raster stack in numpy format with associated metadata.
```

3. Added summary description of each document in earthpy to index.rst