### PR TITLE
Add .rst file documentation for the draw_legend function and fix two misspellings in spatial.py

### DIFF
--- a/docs/spatial-raster.rst
+++ b/docs/spatial-raster.rst
@@ -52,7 +52,7 @@ Example:
 
 
 Draw Legend
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 The ``draw_legend`` function creates a custom legend with a box for each class in a raster using a maptplotlib image object, the unique classes in the image, and titles for each class.
 

--- a/docs/spatial-raster.rst
+++ b/docs/spatial-raster.rst
@@ -49,3 +49,57 @@ Example:
 
     # Stack landsat tif files
     arr, arr_meta = es.stack_raster_tifs(all__paths, destfile)
+
+
+Draw Legend
+~~~~~~~~~~~~~~~~~~
+
+The ``draw_legend`` function creates a custom legend with a box for each class in a raster using a maptplotlib image object, the unique classes in the image, and titles for each class.
+
+This function requires the matplotlib Python plotting library.
+
+The ``draw_legend`` function takes five input parameters, two of which are optional:
+
+``im``: matplotlib image object
+      This is the image returned from a call to imshow().
+``classes``: list
+      This is a list of unique values found in the numpy array that you wish to plot.
+``titles``: list
+      This is a list of a title or category for each unique value in your raster. This will act as a label that will go next to each box in your legend.
+``bbox``: tuple (optional)
+      This is the bbox_to_anchor argument that will place the legend anywhere on or around your plot.  The default value is (1.05, 1).
+``loc``: integer (optional)
+      This is the maptplotlib location value that can be used to specify the location of the legend on your plot. The default value is 2.        
+
+
+The default output of ``draw_legend`` is:
+
+* A matplotlib legend object to be displayed as part of your plot.
+
+
+Example:
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+    import earthpy.spatial as es
+
+    # Create list of category names for legend labels
+    category_names = ["Extreme",
+                      "Very High",
+                      "Moderate",
+                      "Low",
+                      "Very Low"]
+
+   # Create list of values from the numpy array
+   values = np.unique(example_raster.ravel())
+
+    # Plot the data with earthpy custom legend
+    fig, ax = plt.subplots(figsize=(10, 8))
+    im = ax.imshow(example_raster,
+                   cmap=PiYG,
+                   extent=example_extent)
+
+    es.draw_legend(im, 
+                   classes=values,
+                   titles=category_names)

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -65,7 +65,7 @@ def normalized_diff(b1, b2):
 # EL function
 # we probably want to include a no data value here if provided ...
 def stack_raster_tifs(band_paths, out_path, arr_out=True):
-    """Take a list of raster paths and turn into an ouput raster stack in numpy format.
+    """Take a list of raster paths and turn into an output raster stack in numpy format.
     Note that this function depends upon the stack() function.
 
     Parameters
@@ -501,7 +501,7 @@ def draw_legend(im, classes, titles, bbox=(1.05, 1), loc=2):
     classes : list
         A list of unique values found in the numpy array that you wish to plot.
     titles : list
-        A list of a title or category for each uique value in your raster. This is the
+        A list of a title or category for each unique value in your raster. This is the
         label that will go next to each box in your legend.
     bbox : optional, tuple
         This is the bbox_to_anchor argument that will place the legend anywhere on or around your plot.


### PR DESCRIPTION
@lwasser Added documentation for draw_legend functon to spatial-raster.rst and fixed misspelling of the word 'output' in stack_raster_tifs code in spatial.py.  While reviewing the code for the draw_legend function in spatial.py, I also noticed that the word 'unique' was misspelled.  I did not see a reported issue for that elsewhere so I went ahead and fixed that as well. These updates are for the items listed in this issue: https://github.com/earthlab/earthpy/issues/63 