### PR TITLE
Udated plot_bands documentation (spelling errors, added missing "title" parameter) AND made online documentation for plot_bands in spatial-raster.rst

### DIFF
--- a/docs/spatial-raster.rst
+++ b/docs/spatial-raster.rst
@@ -13,7 +13,7 @@ into an
 1. a stacked geotiff on your hard drive and
 2. (optionally) an output raster stack in numpy format with associated metadata.
 
-All files in the list must be in the same Coordinate Refenence System (CRS) and
+All files in the list must be in the same Coordinate Reference System (CRS) and
 must have the same spatial extent for this to work properly.
 
 ``stack_raster_tifs`` takes 3 input parameters:
@@ -52,3 +52,40 @@ Example:
 
     # Stack landsat tif files
     arr, arr_meta = es.stack_raster_tifs(all__paths, destfile)
+
+
+Plot Raster File Bands
+~~~~~~~~~~~~~~~~~~
+
+The ``plot_bands`` function displays a quick visualization of each raster file band
+individually as matplotlib plot(s). This function is helpful when first exploring raster data.
+
+``plot_bands`` takes 6 input parameters:
+
+``arr``: numpy array
+    a n dimension numpy array
+``title``: str or list
+    string for a single title of one band or list of x titles for x bands in plot
+``cmap``: str
+    cmap name, string the colormap that you wish to use (greys = default)
+``cols``: int
+    the number of columns you want to plot in
+``figsize``: tuple - optional
+    the figure size if you'd like to define it. default: (12, 12)
+``extent``: list or geopandas dataframe - optional
+    an extent object for plotting. Values should be in the order: minx, miny, maxx, maxy
+
+
+Example:
+
+.. code-block:: python
+
+    import earthpy.spatial as es
+
+    titles = ["Red Band", "Green Band", "Blue Band", "Near Infrared (NIR) Band"]
+
+    # Plot all bands of a raster tif
+    es.plot_bands(naip_image,
+                  title=titles,
+                  figsize=(12,5),
+                  cols=2)

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -73,7 +73,7 @@ def stack_raster_tifs(band_paths, out_path, arr_out=True):
         A list with paths to the bands you wish to stack. Bands
         will be stacked in the order given in this list.
     out_path : string
-        A path with a file name for the output stacked raster 
+        A path with a file name for the output stacked raster
          tif file.
     arr_out : boolean
         A boolean argument to designate what is returned in the stacked
@@ -285,11 +285,19 @@ def plot_bands(arr, title = None, cmap = "Greys_r", figsize=(12,12), cols = 3, e
 
     Parameters
     ----------
-    arr: a n dimension numpy array
-    cmap: cmap name, str the colormap that you wish to use (greys = default)
-    cols: int the number of columsn you want to plot in
-    figsize: tuple. the figsize if you'd like to define it. default: (12, 12)
-    extent: an extent object for plotting
+    arr: numpy array
+        a n dimension numpy array
+    title: str or list
+        string for a single title of one band or list of x titles for x band in plot
+    cmap: str
+        cmap name string of the colormap that you wish to use (greys = default)
+    cols: int
+        the number of columns you want to plot in
+    figsize: tuple - optional
+        the figsize if you'd like to define it. default: (12, 12)
+    extent: list or geopandas dataframe - optional
+        an extent object for plotting. Values should be in the order: minx, miny, maxx, maxy
+
     Return
     ----------
     matplotlib plot of all layers


### PR DESCRIPTION
In this change, I fixed up some spelling errors in earthpy (columsn --> columns, Refenence --> Reference), added the missing parameter "title" to `plot_bands`, and re-organized the `plot_bands` Parameters section.


I also created online documentation for `plot_bands`.


Changes proposed in issue #58 
