### PR TITLE
Deleted whitespace in clip.py code AND Capitalized 'Test' in spatial.py code

### DIFF
--- a/earthpy/clip.py
+++ b/earthpy/clip.py
@@ -9,7 +9,6 @@ def clip_points(shp, clip_obj):
     '''
     Docs Here
     '''
-
     poly = clip_obj.geometry.unary_union
     return(shp[shp.geometry.intersects(poly)])
 
@@ -37,7 +36,6 @@ def clip_line_poly(shp, clip_obj):
 
     # Return the clipped layer with no null geometry values
     return(clipped[clipped.geometry.notnull()])
-
 
 # Final clip function that handles points, lines and polygons
 

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -319,7 +319,7 @@ def plot_bands(arr, title=None, cmap="Greys_r", figsize=(12, 12), cols=3, extent
     """
     # If the array is 3 dimensional setup grid plotting
     if arr.ndim > 2 and arr.shape[0] > 1:
-        # test if there are enough titles to create plots
+        # Test if there are enough titles to create plots
         if title:
             if not (len(title) == arr.shape[0]):
                 raise ValueError("The number of plot titles should be the same " +


### PR DESCRIPTION
I thought there was going to be more to clean up in the clip.py code but Pep8 standards said otherwise! @mbjoseph 