### PR TITLE
Adding pytest fixtures for re-used test data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = earthpy/tests*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = earthpy/tests*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This package uses [pytest](https://pytest.org/) for tests.
 To run tests locally, execute the command `pytest` from the command line:
 
 ```
-pytest
+>>>pytest
 ```
 
 ### Fake data for testing

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ To install, use pip. `--upgrade` is optional but it ensures that the package ove
 when you install and you have the current version. If you don't have the package
 yet you can still use the `--upgrade` argument.
 
-`pip install --upgrade git+https://github.com/earthlab/earthpy.git`
+```bash
+$ pip install --upgrade git+https://github.com/earthlab/earthpy.git
+```
 
 Then import it into python.
 
-`import earthpy as et`
+```python
+>>> import earthpy as et
+```
 
 
 ## Contributors
@@ -33,14 +37,14 @@ Then import it into python.
 This package uses [pytest](https://pytest.org/) for tests.
 To run tests locally, execute the command `pytest` from the command line:
 
-```
->>>pytest
+```bash
+$ pytest
 ```
 
-### Fake data for testing
+### Data generated for testing
 
 If a test requires a data object such as a GeoDataFrame or numpy array, and
-copies of that data object is required by multiple tests, we can use [pytest
+copies of that data object are required by multiple tests, we can use [pytest
 fixtures](https://docs.pytest.org/en/latest/fixture.html) to cleanly create
 and tear down those objects independently for each test.
 

--- a/README.md
+++ b/README.md
@@ -31,4 +31,19 @@ Then import it into python.
 ## Testing
 
 This package uses [pytest](https://pytest.org/) for tests.
-To run tests locally, execute the command `pytest` from the command line.
+To run tests locally, execute the command `pytest` from the command line:
+
+```
+pytest
+```
+
+### Fake data for testing
+
+If a test requires a data object such as a GeoDataFrame or numpy array, and
+copies of that data object is required by multiple tests, we can use [pytest
+fixtures](https://docs.pytest.org/en/latest/fixture.html) to cleanly create
+and tear down those objects independently for each test.
+
+See [`earthpy/tests/conftest.py`](earthpy/tests/conftest.py) for fixture
+definitions, and [`earthpy/tests/test_clip.py`](earthpy/tests/test_clip.py)
+for example usage of fixtures in tests.

--- a/earthpy/tests/conftest.py
+++ b/earthpy/tests/conftest.py
@@ -1,0 +1,91 @@
+""" Utility functions for tests. """
+import numpy as np
+import pytest
+from shapely.geometry import Polygon, Point, LineString
+import geopandas as gpd
+
+
+def make_locs_gdf():
+    """ Create a dummy point GeoDataFrame. """
+    pts = np.array([[2, 2],
+                    [3, 4],
+                    [9, 8],
+                    [-12, -15]])
+    gdf = gpd.GeoDataFrame([Point(xy) for xy in pts],
+                           columns=['geometry'],
+                           crs={'init': 'epsg:4326'})
+    return gdf
+
+
+def make_poly_in_gdf():
+    """ Bounding box polygon. """
+    poly_inters = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
+    gdf = gpd.GeoDataFrame([1],
+                           geometry=[poly_inters],
+                           crs={'init': 'epsg:4326'})
+    return gdf
+
+
+def make_locs_buff():
+    """ Buffer points to create multi poly. """
+    buffered_locations = make_locs_gdf()
+    buffered_locations["geometry"] = buffered_locations.buffer(4)
+    return buffered_locations
+
+
+def make_donut_geom():
+    """ Make a donut geometry. """
+    donut = gpd.overlay(make_locs_buff(), make_poly_in_gdf(),
+                        how='symmetric_difference')
+    return donut
+
+
+@pytest.fixture
+def locs_gdf():
+    """ Get a dummy point GeoDataFrame.
+
+    This fixture calls make_locs_gdf(), which is a function that is used in
+    multiple fixtures. But, fixtures are not supposed to be used like that:
+
+    see https://github.com/pytest-dev/pytest/issues/3950 for discussion
+    """
+    return make_locs_gdf()
+
+
+@pytest.fixture
+def linez_gdf():
+    """ Create Line Objects For Testing """
+    linea = LineString([(1, 1), (2, 2), (3, 2), (5, 3)])
+    lineb = LineString([(3, 4), (5, 7), (12, 2), (10, 5), (9, 7.5)])
+    gdf = gpd.GeoDataFrame([1, 2],
+                           geometry=[linea, lineb],
+                           crs={'init': 'epsg:4326'})
+    return gdf
+
+
+@pytest.fixture
+def poly_in_gdf():
+    """ Fixture for a bounding box polygon. """
+    return make_poly_in_gdf()
+
+
+@pytest.fixture
+def locs_buff():
+    """ Fixture for buffered locations. """
+    return make_locs_buff()
+
+
+@pytest.fixture
+def donut_geom():
+    """ Fixture for donut geometry objects. """
+    return make_donut_geom()
+
+
+@pytest.fixture
+def multi_gdf():
+    """ Create a multi-polygon GeoDataFrame. """
+    multi_poly = make_donut_geom().unary_union
+    out_df = gpd.GeoDataFrame(gpd.GeoSeries(multi_poly),
+                              crs={'init': 'epsg:4326'})
+    out_df = out_df.rename(columns={0: 'geometry'}).set_geometry('geometry')
+    return out_df

--- a/earthpy/tests/test_clip.py
+++ b/earthpy/tests/test_clip.py
@@ -1,70 +1,13 @@
 """Tests for the clip module."""
 
-import numpy as np
 import pytest
-from shapely.geometry import Polygon, Point, LineString
+from shapely.geometry import Polygon
 import shapely
 import geopandas as gpd
 import earthpy.clip as cl
 
 
-""" Setup dummy data for tests """
-
-pts = np.array([[2, 2],
-                [3, 4],
-                [9, 8],
-                [-12, -15]])
-
-locs = [Point(xy) for xy in pts]
-locs_gdf = gpd.GeoDataFrame(locs,
-                            columns=['geometry'],
-                            crs={'init': 'epsg:4326'})
-
-# TODO? Create a create gdf from list function since we do it like 3
-# times in this test file already
-
-
-""" Create Line Objects For Testing """
-
-linea = LineString([(1, 1), (2, 2), (3, 2), (5, 3)])
-lineb = LineString([(3, 4), (5, 7), (12, 2), (10, 5), (9, 7.5)])
-
-linez_gdf = gpd.GeoDataFrame([1, 2],
-                             geometry=[linea, lineb],
-                             crs={'init': 'epsg:4326'})
-
-""" Create Polygon Objects For Testing """
-
-# Create crop box
-poly_inters = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
-poly_in_gdf = gpd.GeoDataFrame([1],
-                               geometry=[poly_inters],
-                               crs={'init': 'epsg:4326'})
-
-# Shift by 20
-poly_out_gdf = poly_in_gdf.copy()
-poly_out_gdf = poly_in_gdf.geometry.apply(lambda x: shapely.affinity.
-                                          translate(x, xoff=20, yoff=20))
-# Buffer points to create multi poly
-locs_buff = locs_gdf.copy()
-locs_buff["geometry"] = locs_gdf.buffer(4)
-
-# Create geom w "donut hole"
-donut_geom = gpd.overlay(locs_buff, poly_in_gdf,
-                         how='symmetric_difference')
-
-multi_poly = donut_geom.unary_union
-multi_gdf = gpd.GeoDataFrame(gpd.GeoSeries(multi_poly),
-                             crs={'init': 'epsg:4326'})
-multi_gdf = multi_gdf.rename(columns={0: 'geometry'}).\
-    set_geometry('geometry')
-
-
-
-""" Run clip shape tests """
-
-
-def test_returns_gdf():
+def test_returns_gdf(locs_gdf, poly_in_gdf):
     """Test that function returns a GeoDataFrame (or GDF-like) object."""
     out = cl.clip_shp(locs_gdf, poly_in_gdf)
     assert hasattr(out, 'geometry')
@@ -72,25 +15,32 @@ def test_returns_gdf():
 
 def test_non_overlapping_geoms():
     """Test that a bounding box returns error if the extents don't overlap"""
+    unit_box = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
+    unit_gdf = gpd.GeoDataFrame([1],
+                                geometry=[unit_box],
+                                crs={'init': 'epsg:4326'})
+    non_overlapping_gdf = unit_gdf.copy()
+    non_overlapping_gdf = unit_gdf.geometry.apply(lambda x: shapely.affinity.
+                                                  translate(x, xoff=20))
     with pytest.raises(ValueError):
-        cl.clip_shp(locs_gdf, poly_out_gdf)
+        cl.clip_shp(unit_gdf, non_overlapping_gdf)
 
 
-def check_input_gdfs():
+def check_input_gdfs(poly_in_gdf):
     """Test that function fails if not provided with 2 GDFs."""
     with pytest.raises(AssertionError):
-        cl.clip_shp(locs, poly_in_gdf)
+        cl.clip_shp([], poly_in_gdf)
     with pytest.raises(AssertionError):
-        cl.clip_shp(poly_in_gdf, locs)
+        cl.clip_shp(poly_in_gdf, [])
 
 
-def test_clip_points():
+def test_clip_points(locs_gdf, poly_in_gdf):
     """Test clipping a points GDF with a generic polygon geometry."""
     clip_pts = cl.clip_shp(locs_gdf, poly_in_gdf)
     assert len(clip_pts.geometry) == 3 and clip_pts.geom_type[1] == "Point"
 
 
-def test_clip_poly():
+def test_clip_poly(locs_buff, poly_in_gdf):
     """Test clipping a polygon GDF with a generic polygon geometry."""
     clipped_poly = cl.clip_shp(locs_buff, poly_in_gdf)
     assert len(clipped_poly.geometry) == 3
@@ -100,19 +50,19 @@ def test_clip_poly():
 # TODO same test for points and lines
 
 
-def test_clip_multipoly():
+def test_clip_multipoly(poly_in_gdf, multi_gdf):
     """Test that multi poly returns a value error."""
     with pytest.raises(ValueError):
         cl.clip_shp(poly_in_gdf, multi_gdf)
 
 
-def test_clip_donut_poly():
+def test_clip_donut_poly(locs_gdf, donut_geom):
     """Donut holes are multipolygons and should raise ValueErrors."""
     with pytest.raises(ValueError):
         cl.clip_shp(locs_gdf, donut_geom)
 
 
-def test_clip_lines():
+def test_clip_lines(linez_gdf, poly_in_gdf):
     """Test what happens when you give the clip_extent a line GDF."""
     clip_line = cl.clip_shp(linez_gdf, poly_in_gdf)
     assert len(clip_line.geometry) == 2

--- a/earthpy/tests/test_clip.py
+++ b/earthpy/tests/test_clip.py
@@ -7,15 +7,15 @@ import geopandas as gpd
 import earthpy.clip as cl
 
 
-def test_not_gdf():
+def test_not_gdf(poly_in_gdf):
     """Non-GeoDataFrame inputs raise attribute errors."""
     with pytest.raises(AttributeError):
-        cl.clip_shp((2, 3), poly_out_gdf)
+        cl.clip_shp((2, 3), poly_in_gdf)
     with pytest.raises(AttributeError):
-        cl.clip_shp(poly_out_gdf, (2, 3))
+        cl.clip_shp(poly_in_gdf, (2, 3))
 
 
-def test_returns_gdf():
+def test_returns_gdf(locs_gdf, poly_in_gdf):
     """Test that function returns a GeoDataFrame (or GDF-like) object."""
     out = cl.clip_shp(locs_gdf, poly_in_gdf)
     assert hasattr(out, 'geometry')
@@ -37,9 +37,9 @@ def test_non_overlapping_geoms():
 def check_input_gdfs(poly_in_gdf):
     """Test that function fails if not provided with 2 GDFs."""
     with pytest.raises(AssertionError):
-        cl.clip_shp([], poly_in_gdf)
+        cl.clip_shp(list(), poly_in_gdf)
     with pytest.raises(AssertionError):
-        cl.clip_shp(poly_in_gdf, [])
+        cl.clip_shp(poly_in_gdf, list())
 
 
 def test_clip_points(locs_gdf, poly_in_gdf):

--- a/earthpy/tests/test_mask.py
+++ b/earthpy/tests/test_mask.py
@@ -1,6 +1,1 @@
-import numpy as np
-import pytest
-import rasterio as rio
-
-
-"""Functions for the mask module"""
+""" Tests for the mask module. """

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from shapely.geometry import Polygon, Point
 import geopandas as gpd
-from earthpy import spatial as es
+import earthpy.spatial as es
 
 
 def test_extent_to_json():

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -1,19 +1,12 @@
+""" Tests for the spatial module. """
 
-"""Tests for the spatial module"""
-
-from earthpy import spatial as es
 import numpy as np
-import pytest
-
-
 import pandas as pd
-import numpy as np
 import pytest
-from shapely.geometry import Polygon, Point, LineString
-import shapely
+from shapely.geometry import Polygon, Point
 import geopandas as gpd
-import earthpy.spatial as es
-import earthpy.clip as cl
+from earthpy import spatial as es
+
 
 def test_extent_to_json():
     """"Unit tests for extent_to_json()."""
@@ -27,13 +20,13 @@ def test_extent_to_json():
     assert list_poly.length == 4
 
     # Providing a GeoDataFrame creates identical output
-    df = pd.DataFrame(
+    points_df = pd.DataFrame(
         {'lat': [0, 1],
          'lon': [0, 1]}
     )
-    df['coords'] = list(zip(df.lon, df.lat))
-    df['coords'] = df['coords'].apply(Point)
-    gdf = gpd.GeoDataFrame(df, geometry='coords')
+    points_df['coords'] = list(zip(points_df.lon, points_df.lat))
+    points_df['coords'] = points_df['coords'].apply(Point)
+    gdf = gpd.GeoDataFrame(points_df, geometry='coords')
     gdf_out = es.extent_to_json(gdf)
     assert gdf_out == list_out
 
@@ -48,44 +41,39 @@ def test_extent_to_json():
     with pytest.raises(AssertionError):
         es.extent_to_json([0, 1, 1, 0])
 
+
 def test_bytescale_high_low_val():
     """"Unit tests for earthpy.spatial.bytescale """
-    
-    arr = np.random.randint(300, size=(10,10))
-    
+
+    arr = np.random.randint(300, size=(10, 10))
+
     # Bad high value
     with pytest.raises(ValueError):
         es.bytescale(arr, high=300)
-        
+
     # Bad low value
     with pytest.raises(ValueError):
         es.bytescale(arr, low=-100)
-        
+
     # High value is less than low value
     with pytest.raises(ValueError):
         es.bytescale(arr, high=100, low=150)
-        
+
     # Valid case. should also take care of if statements for cmin/cmax
     val_arr = es.bytescale(arr, high=255, low=0)
-        
+
     assert val_arr.min() == 0
     assert val_arr.max() == 255
-    
+
     # Test scale value max is less than min
     with pytest.raises(ValueError):
         es.bytescale(arr, cmin=100, cmax=50)
-        
-        
+
     # Test scale value max is less equal to min
     es.bytescale(arr, cmin=100, cmax=100)
-    # assert something    
-        
+    # TODO: add assertion here
+
     # Test scale value max is less equal to min
     scale_arr = es.bytescale(arr, cmin=10, cmax=240)
     assert scale_arr.min() == 0
     assert scale_arr.max() == 255
-
-        
-        
-    
-


### PR DESCRIPTION
Our original idea was to add a utility functions script to the tests directory, and then use those utility functions in test modules to simulate fake data. But the best practice for pytest seems instead to use fixtures, which are functions that generate objects required for tests to run. Each test takes fixture names as arguments, and then executes those fixture functions to create fake data independent for each test. Creating the data independently for each test is more robust than creating shared data in a global environment that is used by multiple tests. 

Fixtures used by multiple test modules are defined in `earthpy/tests/conftest.py`. 

I found these links on fixtures to be helpful in wrapping my head around the concept: 

- https://docs.pytest.org/en/latest/fixture.html
- https://blog.daftcode.pl/the-cleaning-hand-of-pytest-28f434f4b684

@lwasser have a look, and let me know if you have questions/changes! I added some info to the README to remind ourselves later of how we use fixtures. I also cleaned up some flake8 and pylint formatting issues in some of the other test modules as part of this PR. Relates to #118 