### PR TITLE
Extend data loader to fetch arbitrary URLs

### DIFF
--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -112,6 +112,12 @@ class EarthlabData(object):
                 if fname.endswith(kind):
                     file_type = kind
 
+            # strip off the file extension so we get pretty download
+            # directories
+            if file_type != 'file':
+                # cut off an extra character to remove the trailing dot as well
+                fname = fname[:-(len(file_type) + 1)]
+
             this_data = (url, fname, file_type)
             this_root = op.join(self.path, "unsorted")
 

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -4,6 +4,9 @@
 
 import os
 import os.path as op
+
+import requests
+
 from download import download
 
 
@@ -48,7 +51,7 @@ class EarthlabData(object):
         s = 'Available Datasets: {}'.format(self.data_keys)
         return s
 
-    def get_data(self, key=None, replace=False):
+    def get_data(self, key=None, replace=False, url=None):
         """
         Retrieve the data for a given week and return its path.
 
@@ -59,7 +62,11 @@ class EarthlabData(object):
         ----------
         key : str
             The dataset to retrieve. Possible options can be found in
-            ``self.data_keys``.
+            ``self.data_keys``. Note: ``key`` and ``url`` are mutually
+            exclusive.
+        url : str
+            A URL to fetch into the data directory. Use this for ad-hoc dataset
+            downloads. Note: ``key`` and ``url`` are mutually exclusive.
         replace : bool
             Whether to replace the data for this key if it is
             already downloaded.
@@ -69,32 +76,62 @@ class EarthlabData(object):
         path_data : str
             The path to the downloaded data.
         """
-        if key is None:
+        if key is not None and url is not None:
+            raise ValueError("The `url` and `key` parameters can not both be "
+                             "set at the same time.")
+        if key is None and url is None:
             print('Available datasets: {}'.format(
                 list(DATA_URLS.keys())))
-        elif key not in DATA_URLS:
-            raise ValueError("Don't understand key "
-                             "{}\nChoose one of {}".format(
-                             key, DATA_URLS.keys()))
-        else:
-            this_root = op.join(self.path, key)
-            this_data = DATA_URLS[key]
-            if not isinstance(this_data, list):
-                this_data = [this_data]
-            data_paths = []
-            for url, name, kind in this_data:
-                if kind not in ALLOWED_FILE_TYPES:
-                    raise ValueError('kind must be one of {}, got {}'.format(ALLOWED_FILE_TYPES, kind))
+            return
 
-                # If kind is not 'file' it will be un-archived to a folder w/ `name`
-                # else create a file called `name`
-                this_path = download(url, os.path.join(this_root, name),
-                                     replace=replace, kind=kind,
-                                     verbose=False)
-                data_paths.append(this_path)
-            if len(data_paths) == 1:
-                data_paths = data_paths[0]
-            return data_paths
+        if key is not None:
+            if key not in DATA_URLS:
+                raise ValueError("Don't understand key "
+                                 "{}\nChoose one of {}".format(
+                                     key, DATA_URLS.keys()))
+
+            this_data = DATA_URLS[key]
+            this_root = op.join(self.path, key)
+
+        if url is not None:
+            # try and workout the filename and file type
+            fname = None
+            r = requests.head(url)
+            content_disposition = r.headers['content-disposition'].split(';')
+            for c in content_disposition:
+                if c.startswith('filename='):
+                    fname = c.split('=')[1]
+                    break
+            else:
+                raise RuntimeError("Could not deduce filename for "
+                                   "{}.".format(url))
+
+            # try and deduce filetype
+            file_type = 'file'
+            for kind in ALLOWED_FILE_TYPES:
+                if fname.endswith(kind):
+                    file_type = kind
+
+            this_data = (url, fname, file_type)
+            this_root = op.join(self.path, "unsorted")
+
+        if not isinstance(this_data, list):
+            this_data = [this_data]
+
+        data_paths = []
+        for url, name, kind in this_data:
+            if kind not in ALLOWED_FILE_TYPES:
+                raise ValueError('kind must be one of {}, got {}'.format(ALLOWED_FILE_TYPES, kind))
+
+            # If kind is not 'file' it will be un-archived to a folder w/ `name`
+            # else create a file called `name`
+            this_path = download(url, os.path.join(this_root, name),
+                                 replace=replace, kind=kind,
+                                 verbose=False)
+            data_paths.append(this_path)
+        if len(data_paths) == 1:
+            data_paths = data_paths[0]
+        return data_paths
 
 
 # Potential functionality for website build.


### PR DESCRIPTION
This extends the data loader so that you can pass it a URL instead of a predefined key.

```python
In [2]: d = EarthlabData("/tmp/ea")

In [3]: d.get_data(url="https://ndownloader.figshare.com/files/10960109")
```

will create a directory called `/tmp/ea/unsorted/cold-springs-fire/` which contains the unzipped contents of the file from the URL. It tries its best to guess what the file type is and what to name things.