### PR TITLE
List package versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - conda info -a
   - conda env create -f environment.yml
   - source activate earthpy-dev
+  - conda list
   - python setup.py install
   - pip install -r dev-requirements.txt
 


### PR DESCRIPTION
@lwasser This PR should force Travis to print the output from `conda list` after activating the environment. That way we can see what versions of each package are installed in Travis for debugging.