### PR TITLE
Fix test that previously did not run

### DIFF
--- a/earthpy/tests/test_clip.py
+++ b/earthpy/tests/test_clip.py
@@ -34,11 +34,11 @@ def test_non_overlapping_geoms():
         cl.clip_shp(unit_gdf, non_overlapping_gdf)
 
 
-def check_input_gdfs(poly_in_gdf):
+def test_input_gdfs(poly_in_gdf):
     """Test that function fails if not provided with 2 GDFs."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(AttributeError):
         cl.clip_shp(list(), poly_in_gdf)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AttributeError):
         cl.clip_shp(poly_in_gdf, list())
 
 


### PR DESCRIPTION
Previously we had a test called `check_input_gdfs` in the `test_clip.py` module that did not execute: https://codecov.io/gh/earthlab/earthpy/src/master/earthpy/tests/test_clip.py#L39...42 

It never ran because it was not prefixed with `test_*`. This pull request updates the test's name so that it actually runs, and fixes an error in the test (previously we had expected an `AssertionError`, but really we need an `AttributeError`). 

One lesson here is that inspecting code coverage **of the tests** is useful to ensure that tests are actually executed.