### PR TITLE
Add black as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/ambv/black
+  rev: stable
+  hooks:
+  - id: black
+    language_version: python3.6

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,6 +20,10 @@ When submitting a change to the repository, please do the following:
 
 When submitting a pull request:
 
+- Install the tools needed for development by running
+  `pip install -r dev-requirements.txt` or the equivalent of it for your package
+  manager.
+
 - All existing tests should pass. Please make sure that the test
   suite passes, both locally and on
   `Travis CI <https://travis-ci.org/earthlab/earthpy>`_

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 sphinx==1.8.0
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme
+pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79


### PR DESCRIPTION
This adds `black` as a pre-commit hook.

I followed the link to the blog post Joe linked to and then ended up on https://github.com/ambv/black#version-control-integration which uses the same tool (`pre-commit`) to set things up. Conclusion: I just followed the instructions 😄.

I didn't add `flake8` as a pre-commit hook as I think `black` will reformat changes you made that would violate pep8 in black's steamroller way of dealing with things.

Closes #132