### PR TITLE
Add unit tests for crop_image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,13 @@ install:
   - conda list
   - python setup.py install
   - pip install -r dev-requirements.txt
+  - pip install black
 
 script:
   - pytest  --doctest-modules --cov=earthpy
   # Build documentation
   - pushd docs && make doctest && make html && popd
+  - black --check --verbose .
 
 after_success:
   - codecov

--- a/earthpy/__init__.py
+++ b/earthpy/__init__.py
@@ -12,4 +12,7 @@ data = EarthlabData()
 # https://github.com/jswhit/pyproj/blob/master/lib/pyproj/data/epsg
 
 from pkg_resources import resource_string
-epsg = json.loads(resource_string("earthpy", "example-data/epsg.json").decode("utf-8"))
+
+epsg = json.loads(
+    resource_string("earthpy", "example-data/epsg.json").decode("utf-8")
+)

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -214,22 +214,37 @@ def crop_image(raster, geoms, all_touched=True):
 
     Returns
     ----------
-    out_image: masked numpy array
-        A masked numpy array that is masked / cropped to the geoms object
-        extent
+    out_image: cropped numpy array
+        A numpy ndarray that is cropped to the geoms object
+        extent with shape (bands, rows, columns)
     out_meta:  dict
         A dictionary containing the updated metadata for the cropped raster.
         Specifically the extent (shape elements) and transform properties are
         updated.
-    """
 
+    Example
+    -------
+        >>> import geopandas as gpd
+        >>> import rasterio as rio
+        >>> import earthpy.spatial as es
+        >>> from earthpy.io import path_to_example
+
+        >>> # Clip an RGB image to the extent of Rocky Mountain National Park
+        >>> rmnp = gpd.read_file(path_to_example("rmnp.shp"))
+        >>> with rio.open(path_to_example("rmnp-rgb.tif")) as raster:
+        ...     src_image = raster.read()
+        ...     out_image, out_meta = es.crop_image(raster, rmnp)
+        >>> out_image.shape
+        (3, 265, 281)
+        >>> src_image.shape
+        (3, 373, 485)
+    """
     if type(geoms) == gpd.geodataframe.GeoDataFrame:
-        clip_ext = [extent_to_json(geoms)]
+        clip_extent = [extent_to_json(geoms)]
     else:
-        clip_ext = geoms
-    # Mask the input image and update the metadata
+        clip_extent = geoms
     out_image, out_transform = mask(
-        raster, clip_ext, crop=True, all_touched=all_touched
+        raster, clip_extent, crop=True, all_touched=all_touched
     )
     out_meta = raster.meta.copy()
     out_meta.update(
@@ -240,7 +255,7 @@ def crop_image(raster, geoms, all_touched=True):
             "transform": out_transform,
         }
     )
-    return (out_image, out_meta)
+    return out_image, out_meta
 
 
 def bytescale(data, cmin=None, cmax=None, high=255, low=0):

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -239,7 +239,7 @@ def crop_image(raster, geoms, all_touched=True):
         >>> src_image.shape
         (3, 373, 485)
     """
-    if type(geoms) == gpd.geodataframe.GeoDataFrame:
+    if isinstance(geoms, gpd.geodataframe.GeoDataFrame):
         clip_extent = [extent_to_json(geoms)]
     else:
         clip_extent = geoms

--- a/earthpy/tests/conftest.py
+++ b/earthpy/tests/conftest.py
@@ -2,6 +2,8 @@
 import numpy as np
 import pytest
 from shapely.geometry import Polygon, Point, LineString
+from affine import Affine
+import rasterio as rio
 import geopandas as gpd
 
 
@@ -90,3 +92,74 @@ def multi_gdf():
     )
     out_df = out_df.rename(columns={0: "geometry"}).set_geometry("geometry")
     return out_df
+
+
+@pytest.fixture
+def basic_geometry():
+    """
+    A square polygon spanning (2, 2) to (4.25, 4.25) in x and y directions
+    Borrowed from rasterio/tests/conftest.py
+
+    Returns
+    -------
+    dict: GeoJSON-style geometry object.
+        Coordinates are in grid coordinates (Affine.identity()).
+    """
+    return Polygon([(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)])
+
+
+@pytest.fixture
+def basic_geometry_gdf(basic_geometry):
+    """
+    A GeoDataFrame containing the basic geometry
+
+    Returns
+    -------
+    GeoDataFrame containing the basic_geometry polygon
+    """
+    gdf = gpd.GeoDataFrame(
+        geometry=[basic_geometry], crs={"init": "epsg:4326"}
+    )
+    return gdf
+
+
+@pytest.fixture
+def basic_image():
+    """
+    A 10x10 array with a square (3x3) feature
+    Equivalent to results of rasterizing basic_geometry with all_touched=True.
+    Borrowed from rasterio/tests/conftest.py
+
+    Returns
+    -------
+    numpy ndarray
+    """
+    image = np.zeros((10, 10), dtype=np.uint8)
+    image[2:5, 2:5] = 1
+    return image
+
+
+@pytest.fixture
+def basic_image_tif(tmpdir, basic_image):
+    """
+    A GeoTIFF representation of the basic_image array.
+    Borrowed from rasterio/tests/conftest.py
+
+    Returns
+    -------
+    string path to raster file
+    """
+    outfilename = str(tmpdir.join("basic_image.tif"))
+    kwargs = {
+        "crs": rio.crs.CRS({"init": "epsg:4326"}),
+        "transform": Affine.identity(),
+        "count": 1,
+        "dtype": rio.uint8,
+        "driver": "GTiff",
+        "width": basic_image.shape[1],
+        "height": basic_image.shape[0],
+        "nodata": None,
+    }
+    with rio.open(outfilename, "w", **kwargs) as out:
+        out.write(basic_image, indexes=1)
+    return outfilename

--- a/earthpy/tests/test_io.py
+++ b/earthpy/tests/test_io.py
@@ -28,7 +28,7 @@ def test_valid_datasets_get_returned():
 
 def test_rgb():
     """ Check assumptions about rgb satellite imagery over RMNP. """
-    with rio.open(path_to_example('rmnp-rgb.tif')) as src:
+    with rio.open(path_to_example("rmnp-rgb.tif")) as src:
         rgb = src.read()
         rgb_crs = src.crs
     assert rgb.shape == (3, 373, 485)
@@ -37,33 +37,33 @@ def test_rgb():
 
 def test_rgb_single_channels():
     """ Check assumptions about single channel R, G, and B images. """
-    fnames = [path_to_example(f) for f in ['red.tif', 'green.tif', 'blue.tif']]
+    fnames = [path_to_example(f) for f in ["red.tif", "green.tif", "blue.tif"]]
     rgb_parts = list()
     for f in fnames:
         with rio.open(f) as src:
             rgb_parts.append(src.read())
             assert str(src.crs) == "+init=epsg:4326"
 
-    with rio.open(path_to_example('rmnp-rgb.tif')) as src:
+    with rio.open(path_to_example("rmnp-rgb.tif")) as src:
         assert np.array_equal(src.read(), np.concatenate(rgb_parts))
 
 
 def test_colorado_counties():
     """ Check assumptions about county polygons. """
-    counties = gpd.read_file(path_to_example('colorado-counties.geojson'))
+    counties = gpd.read_file(path_to_example("colorado-counties.geojson"))
     assert counties.shape == (64, 13)
-    assert counties.crs == {'init': 'epsg:4326'}
+    assert counties.crs == {"init": "epsg:4326"}
 
 
 def test_colorado_glaciers():
     """ Check assumptions about glacier point locations. """
-    glaciers = gpd.read_file(path_to_example('colorado-glaciers.geojson'))
+    glaciers = gpd.read_file(path_to_example("colorado-glaciers.geojson"))
     assert glaciers.shape == (134, 2)
-    assert glaciers.crs == {'init': 'epsg:4326'}
+    assert glaciers.crs == {"init": "epsg:4326"}
 
 
 def test_continental_divide_trail():
     """ Check assumptions about Continental Divide Trail path. """
-    cdt = gpd.read_file(path_to_example('continental-div-trail.geojson'))
+    cdt = gpd.read_file(path_to_example("continental-div-trail.geojson"))
     assert cdt.shape == (1, 2)
-    assert cdt.crs == {'init': 'epsg:4326'}
+    assert cdt.crs == {"init": "epsg:4326"}

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -1,13 +1,9 @@
 """ Tests for the spatial module. """
 
-import os
 import numpy as np
 import pandas as pd
 import pytest
-from affine import Affine
 import geopandas as gpd
-from osgeo import gdal
-from osgeo import osr
 import rasterio as rio
 from shapely.geometry import Polygon, Point, LineString
 import earthpy.spatial as es
@@ -125,21 +121,6 @@ def test_crop_image_with_geometry(basic_image_tif, basic_geometry):
     """ Cropping with a geometry works with all_touched=True. """
     with rio.open(basic_image_tif) as src:
         img, meta = es.crop_image(src, [basic_geometry], all_touched=True)
-    assert np.sum(img) == 9
-
-
-def test_crop_image_with_geometry_touch_false(basic_image_tif, basic_geometry):
-    """ Cropping with a geometry works with all_touched=False. """
-    with rio.open(basic_image_tif) as src:
-        img, meta = es.crop_image(src, [basic_geometry], all_touched=False)
-    assert np.sum(img) == 4
-
-
-def test_crop_image_with_geojson(basic_image_tif, basic_geometry):
-    """ Cropping with GeoJSON works when all_touched=True. """
-    geojson = basic_geometry.__geo_interface__
-    with rio.open(basic_image_tif) as src:
-        img, meta = es.crop_image(src, [geojson], all_touched=True)
     assert np.sum(img) == 9
 
 

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -159,5 +159,7 @@ def test_bytescale_high_low_val():
 def test_stack_invalid_out_paths_raise_errors():
     """ If users provide an output path that doesn't exist, raise error. """
     with pytest.raises(ValueError, match="not exist"):
-        es.stack_raster_tifs(band_paths=['fname1.tif', 'fname2.tif'],
-                             out_path="nonexistent_directory/output.tif")
+        es.stack_raster_tifs(
+            band_paths=["fname1.tif", "fname2.tif"],
+            out_path="nonexistent_directory/output.tif",
+        )

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -170,7 +170,7 @@ def test_crop_image_with_one_point_raises_error(basic_image_tif):
             es.crop_image(src, [point])
 
 
-def crop_image_with_1d_extent_raises_error(basic_image_tif):
+def test_crop_image_with_1d_extent_raises_error(basic_image_tif):
     """ Cropping with a horizontal or vertical line raises an error. """
     line = LineString([(1, 1), (2, 1), (3, 1)])
     with rio.open(basic_image_tif) as src:

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -1,80 +1,16 @@
 """ Tests for the spatial module. """
 
+import os
 import numpy as np
 import pandas as pd
 import pytest
-from shapely.geometry import Polygon, Point
+from affine import Affine
 import geopandas as gpd
-import earthpy.spatial as es
 from osgeo import gdal
 from osgeo import osr
 import rasterio as rio
-import os
-
-# A helper function to write a 3D array of data to disk as a GeoTIFF
-# The result will have no spatial info or relevance
-def create_tif_file(arr, destfile):
-    """Writes a tif file to a specified location using an array.
-    Parameters
-    ----------
-    arr : numpy ndarray
-        The array should have 3 dimensions, arranged such that
-        a the result of arr.shape is in the form [rows, columns, channels].
-
-    destfile : filepath string
-        The filepath for where the GeoTIFF file will be written.
-    """
-    # Make sure the array is 3 dimensional, assuming last dimension is number of bands
-    assert len(arr.shape) == 3
-
-    try:
-        geotrans = (0, 1, 0, 0, 0, -1)
-
-        # Get the dimensions of the array
-        y_pixels, x_pixels, n_channels = arr.shape
-
-        # Create the GeoTIFF file
-        driver = gdal.GetDriverByName("GTiff")
-        dataset = driver.Create(
-            destfile, x_pixels, y_pixels, int(n_channels), gdal.GDT_Float32
-        )
-
-        # Write the bands to the GeoTIFF
-        for i in range(n_channels):
-            dataset.GetRasterBand(i + 1).WriteArray(arr[:, :, i])
-
-        # Define the Unknown projection
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(0)
-        proj = srs.ExportToWkt()
-
-        # Set the spatial properties of the GeoTIFF file
-        dataset.SetGeoTransform(geotrans)
-        dataset.SetProjection(proj)
-
-        dataset.FlushCache()
-
-        # Remove the dataset from memory
-        dataset = None
-
-        return (0, destfile)
-
-    except Exception as e:
-        return (e, None)
-
-
-def test_create_tif_file():
-    """ Testing dummy_tif_writer."""
-    destfile = "dummy.tif"
-    arr = np.ones((5, 5, 1))
-    code, fi = create_tif_file(arr, destfile)
-
-    assert code == 0
-    assert os.path.exists(destfile) is True
-
-    # Clean up the file
-    if os.path.exists(destfile):
-        os.remove(destfile)
+from shapely.geometry import Polygon, Point, LineString
+import earthpy.spatial as es
 
 
 def test_extent_to_json():
@@ -163,3 +99,104 @@ def test_stack_invalid_out_paths_raise_errors():
             band_paths=["fname1.tif", "fname2.tif"],
             out_path="nonexistent_directory/output.tif",
         )
+
+
+def test_crop_image_with_gdf(basic_image_tif, basic_geometry_gdf):
+    """ Cropping with a GeoDataFrame works when all_touched=True.
+
+    Cropping basic_image_tif file with the basic geometry fixture returns
+    all of the cells that have the value 1 in the basic_image_tif fixture
+
+    These fixtures are described in conftest.py
+    """
+    with rio.open(basic_image_tif) as src:
+        img, meta = es.crop_image(src, basic_geometry_gdf, all_touched=True)
+        print(meta)
+    assert np.sum(img) == 9
+
+
+def test_crop_image_with_gdf_touch_false(basic_image_tif, basic_geometry_gdf):
+    """ Cropping with a GeoDataFrame works when all_touched=False. """
+    print([es.extent_to_json(basic_geometry_gdf)])
+    with rio.open(basic_image_tif) as src:
+        img, meta = es.crop_image(src, basic_geometry_gdf, all_touched=False)
+    assert np.sum(img) == 4
+
+
+def test_crop_image_with_geometry(basic_image_tif, basic_geometry):
+    """ Cropping with a geometry works with all_touched=True. """
+    with rio.open(basic_image_tif) as src:
+        img, meta = es.crop_image(src, [basic_geometry], all_touched=True)
+    assert np.sum(img) == 9
+
+
+def test_crop_image_with_geometry_touch_false(basic_image_tif, basic_geometry):
+    """ Cropping with a geometry works with all_touched=False. """
+    with rio.open(basic_image_tif) as src:
+        img, meta = es.crop_image(src, [basic_geometry], all_touched=False)
+    assert np.sum(img) == 4
+
+
+def test_crop_image_with_geojson(basic_image_tif, basic_geometry):
+    """ Cropping with GeoJSON works when all_touched=True. """
+    geojson = basic_geometry.__geo_interface__
+    with rio.open(basic_image_tif) as src:
+        img, meta = es.crop_image(src, [geojson], all_touched=True)
+    assert np.sum(img) == 9
+
+
+def test_crop_image_with_geojson_touch_false(basic_image_tif, basic_geometry):
+    """ Cropping with GeoJSON works when all_touched=False. """
+    geojson = basic_geometry.__geo_interface__
+    with rio.open(basic_image_tif) as src:
+        img, meta = es.crop_image(src, [geojson], all_touched=False)
+    assert np.sum(img) == 4
+
+
+def test_crop_image_when_poly_bounds_image_extent(basic_image_tif):
+    """ When an image is fully contained in a larger polygon, dont crop. """
+    big_polygon = Polygon([(-1, -1), (11, -1), (11, 11), (-1, 11), (-1, -1)])
+    with rio.open(basic_image_tif) as src:
+        img, meta = es.crop_image(src, [big_polygon])
+        src_array = src.read()
+    assert np.array_equal(img, src_array)
+
+
+def test_crop_image_with_one_point_raises_error(basic_image_tif):
+    """ Cropping an image with one point should raise an error. """
+    point = Point([(1, 1)])
+    with rio.open(basic_image_tif) as src:
+        with pytest.raises(ValueError, match="width and height must be > 0"):
+            es.crop_image(src, [point])
+
+
+def crop_image_with_1d_extent_raises_error(basic_image_tif):
+    """ Cropping with a horizontal or vertical line raises an error. """
+    line = LineString([(1, 1), (2, 1), (3, 1)])
+    with rio.open(basic_image_tif) as src:
+        with pytest.raises(ValueError, match="width and height must be > 0"):
+            es.crop_image(src, [line])
+
+
+def test_crop_image_fails_two_rasters(basic_image_tif, basic_geometry):
+    """ crop_image should raise an error if provided two rasters. """
+    with rio.open(basic_image_tif) as src:
+        with pytest.raises(TypeError):
+            es.crop_image(src, src)
+
+
+def test_crop_image_swapped_args(basic_image_tif, basic_geometry):
+    """ If users provide a polygon instead of raster raise an error. """
+    with pytest.raises(AttributeError):
+        es.crop_image(basic_geometry, basic_image_tif)
+    with pytest.raises(AttributeError):
+        es.crop_image(basic_geometry, basic_geometry)
+
+
+def test_crop_image_fails_empty_list(basic_image_tif, basic_geometry):
+    """ If users provide empty list as arg, crop_image fails. """
+    with pytest.raises(AttributeError):
+        es.crop_image(list(), basic_geometry)
+    with rio.open(basic_image_tif) as src:
+        with pytest.raises(ValueError):
+            es.crop_image(src, list())

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -111,13 +111,11 @@ def test_crop_image_with_gdf(basic_image_tif, basic_geometry_gdf):
     """
     with rio.open(basic_image_tif) as src:
         img, meta = es.crop_image(src, basic_geometry_gdf, all_touched=True)
-        print(meta)
     assert np.sum(img) == 9
 
 
 def test_crop_image_with_gdf_touch_false(basic_image_tif, basic_geometry_gdf):
     """ Cropping with a GeoDataFrame works when all_touched=False. """
-    print([es.extent_to_json(basic_geometry_gdf)])
     with rio.open(basic_image_tif) as src:
         img, meta = es.crop_image(src, basic_geometry_gdf, all_touched=False)
     assert np.sum(img) == 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+testpaths = earthpy/tests
+filterwarnings =
+    ignore::rasterio.errors.NotGeoreferencedWarning

--- a/setup.py
+++ b/setup.py
@@ -51,13 +51,15 @@ if __name__ == "__main__":
             "Operating System :: Unix",
             "Operating System :: MacOS",
         ],
-        package_data={DISTNAME: [
-            "example-data/*.json",
-            "example-data/*.tif",
-            "example-data/*.geojson",
-            "example-data/*.shp",
-            "example-data/*.shx",
-            "example-data/*.prj",
-            "example-data/*.dbf"
-        ]},
+        package_data={
+            DISTNAME: [
+                "example-data/*.json",
+                "example-data/*.tif",
+                "example-data/*.geojson",
+                "example-data/*.shp",
+                "example-data/*.shx",
+                "example-data/*.prj",
+                "example-data/*.dbf",
+            ]
+        },
     )


### PR DESCRIPTION
This PR adds unit tests for `crop_image`, with fixtures [borrowed from rasterio](https://github.com/mapbox/rasterio/blob/master/tests/conftest.py) that create raster files and geometries. These eliminate the need for our previous function that would write GeoTIFFs for testing. Using fixtures is more robust, because each test gets its own tif file, and we can leverage some of the existing testing logic developed by the rasterio team. 

Last, as part of working with these fixtures, this PR includes a file `setup.cfg` which tells pytest to ignore a warning that rasterio creates when using the identity affine geotransform.

Closes #70 