### PR TITLE
Run black on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda list
   - python setup.py install
   - pip install -r dev-requirements.txt
-  - conda install black
+  - pip install black
 
 script:
   - pytest  --doctest-modules --cov=earthpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,13 @@ install:
   - conda list
   - python setup.py install
   - pip install -r dev-requirements.txt
+  - conda install black
 
 script:
   - pytest  --doctest-modules --cov=earthpy
   # Build documentation
   - pushd docs && make doctest && make html && popd
+  - black --check --verbose .
 
 after_success:
   - codecov

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,7 @@ if __name__ == "__main__":
     setup(
         configuration=configuration,
         name=DISTNAME,
-        maintainer=MAINTAINER,
-        include_package_data=True,
-        maintainer_email=MAINTAINER_EMAIL,
+        maintainer=MAINTAINER,include_package_data=True,maintainer_email=MAINTAINER_EMAIL,
         description=DESCRIPTION,
         version=VERSION,
         install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ if __name__ == "__main__":
     setup(
         configuration=configuration,
         name=DISTNAME,
-        maintainer=MAINTAINER,include_package_data=True,maintainer_email=MAINTAINER_EMAIL,
+        maintainer=MAINTAINER,
+        include_package_data=True,
+        maintainer_email=MAINTAINER_EMAIL,
         description=DESCRIPTION,
         version=VERSION,
         install_requires=[


### PR DESCRIPTION
This PR will run black on Travis CI to verify that the pre-commit hook has been used locally. It should fail any builds that have commits that black would change, as suggested in https://github.com/earthlab/earthpy/issues/166. 

I am going to push a commit to this branch that should break the build to verify before merging.