### PR TITLE
Add bumpversion and automate PyPI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,37 @@
 language: python
-
 python:
 - 3.6
-
 cache: pip
-
-before_script: # configure a headless display to test plot generation
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
-- sleep 3 # give xvfb some time to start
-
+before_script:
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+- sleep 3
 install:
-  - sudo apt-get update
-  # https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-  - conda env create -f environment.yml
-  - source activate earthpy-dev
-  - conda list
-  - python setup.py install
-  - pip install -r dev-requirements.txt
-  - pip install black
-
+- sudo apt-get update
+- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+- bash miniconda.sh -b -p $HOME/miniconda
+- export PATH="$HOME/miniconda/bin:$PATH"
+- hash -r
+- conda config --set always_yes yes --set changeps1 no
+- conda update -q conda
+- conda info -a
+- conda env create -f environment.yml
+- source activate earthpy-dev
+- conda list
+- python setup.py install
+- pip install -r dev-requirements.txt
+- pip install black
 script:
-  - pytest --doctest-modules --cov=earthpy
-  - make docs
-  - black --check --verbose .
-
+- pytest --doctest-modules --cov=earthpy
+- make docs
+- black --check --verbose .
 after_success:
-  - codecov
-
+- codecov
 deploy:
   provider: pypi
   user: lwasser
   password:
-    secure:
+    secure: MSaRk5RiQFfFvZtoZ6laPZWyvCwoYx6Ev8CpfFeE5lM//sQPl3jTA7Qty1VviM9tku/7YvH/WSolEh4ruNNNkimkLdN+hb3Avoz+n9/OYm7jhmJ2eBpiHQzunBPOaoQ3IQVem85bqi0AR9Zw2he87wbLE6+ngr44RJa/Jck4pL/2LLfmmgKSDkQL3lpquYjvCanTTOA3j7yQkcY9B15Erm9ZBs7jTrkGxNuhvVv3lgwpRLmt5IiQ/LQQnSEA/6/0+/UNIdqNOwF5lfMw5jVc+i1bMTL2hx+xFiFPamXx8YAL5amNY9yBpCHfvHcOGPV7eqK4n2A8oAORdQPxfSxldhVpYuPnhmM8EJPqC3iqQvtEuZare6VhUL5Zq618OpBgC0tJRIKrTN5NgomL0ihUC6/11DLfGnZxKRCR4BbLWCj1guhVuMIMyNmimF7SC6omcxRlEYOxV0QcZTlJ0PvO5dCsxejuVQdgsk80ue0nLtSE9e8FQILSMuDIjidNW1iGLMUWlwp7DdWmGdbTfQrJ7tOWo/kzuOi9AEIPrAJWXecoFLSrqapoBpQvHTBfA5u/QRq8Z8xNdGs0LGqsyyIOISigW6DFrXbiLPpmRAbQfCAt48VuY+h3SS3qA4JGWum0myR1Se55TpXgebDNR8o5aZh6u+S0TSrbiBsjQBwL1TE=
   on:
     tags: true
     repo: earthlab/earthpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,13 @@ script:
 
 after_success:
   - codecov
+
+deploy:
+  provider: pypi
+  user: lwasser
+  password:
+    secure:
+  on:
+    tags: true
+    repo: earthlab/earthpy
+    python: 3.6

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -122,3 +122,15 @@ Style
   standards. Within each grouping, imports should be alphabetized. Always use
   absolute imports when possible, and explicit relative imports for local
   imports when necessary in tests.
+
+Deploying
+~~~~~~~~~
+
+A reminder for the maintainers on how to deploy.
+Make sure all your changes are committed, then run:
+
+$ bumpversion patch # possible: major / minor / patch
+$ git push
+$ git push --tags
+
+Travis will then deploy to PyPI if tests pass.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
+bumpversion
+pre-commit
 sphinx==1.8.0
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme
-pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,12 @@
 testpaths = earthpy/tests
 filterwarnings =
     ignore::rasterio.errors.NotGeoreferencedWarning
+
+[bumpversion]
+current_version = 0.4.3
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = VERSION='{current_version}'
+replace = VERSION='{new_version}'


### PR DESCRIPTION
This PR adds bumpversion as a way to increment versions programmatically, and also adds a skeleton to the Travis build that will automatically deploy new versions of earthpy to PyPI. See the changes in CONTRIBUTING.rst for instructions on how to deploy.

One thing that still needs to be added to this branch @lwasser is your encrypted PyPI password on this line: https://github.com/earthlab/earthpy/compare/add-bumpversion?expand=1#diff-354f30a63fb0907d4ad57269548329e3R43

Instructions for encrypting your password can be found here: https://docs.travis-ci.com/user/deployment/pypi/

@lwasser it would be good if you added your encrypted password to this branch before merging. Note that if your PyPI password contains special characters you need to escape them before encrypting your password. 