### PR TITLE
Add docs prereqs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,10 +48,13 @@ Ready to contribute? Here's how to set up `earthpy` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that tests pass, and examples run::
+5. When you're done making changes, check that tests pass, docs build, and examples run::
 
     $ pytest --doctest-modules
     $ make docs
+
+By default ``make docs`` will only rebuild the documentation if source
+files have changed. To force a rebuild, use ``make -B docs``.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-docs: ## generate Sphinx HTML documentation, including API docs
+docs: docs/*.rst docs/conf.py docs/Makefile earthpy *.rst ## generate html docs
 	rm -f docs/earthpy.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -H "API reference" -o docs/ earthpy earthpy/tests earthpy/example-data

--- a/earthpy/tests/test_spatial.py
+++ b/earthpy/tests/test_spatial.py
@@ -117,19 +117,19 @@ def test_bytescale_high_low_val():
 
     # Bad high value
     with pytest.raises(
-        ValueError, message="`high` should be less than or equal to 255."
+        ValueError, match="`high` should be less than or equal to 255."
     ):
         es.bytescale(arr, high=300)
 
     # Bad low value
     with pytest.raises(
-        ValueError, message="`low` should be greater than or equal to 0."
+        ValueError, match="`low` should be greater than or equal to 0."
     ):
         es.bytescale(arr, low=-100)
 
     # High value is less than low value
     with pytest.raises(
-        ValueError, message="`high` should be greater than or equal to `low`."
+        ValueError, match="`high` should be greater than or equal to `low`."
     ):
         es.bytescale(arr, high=100, low=150)
 
@@ -141,14 +141,14 @@ def test_bytescale_high_low_val():
 
     # Test scale value max is less than min
     with pytest.raises(
-        ValueError, message="`cmax` should be larger than `cmin`."
+        ValueError, match="`cmax` should be larger than `cmin`."
     ):
         es.bytescale(arr, cmin=100, cmax=50)
 
     # Test scale value max is less equal to min. Commented out for now because it breaks stuff somehow.
     with pytest.raises(
         ValueError,
-        message="`cmax` and `cmin` should not be the same value. Please specify `cmax` > `cmin`",
+        match="`cmax` and `cmin` should not be the same value. Please specify `cmax` > `cmin`",
     ):
         es.bytescale(arr, cmin=100, cmax=100)
 


### PR DESCRIPTION
This PR adds prerequisites to the recipe for making docs, so that the command `make docs` with execute only when necessary (when files in the prerequisites have changed). This also adds a smidgen more information to the CONTRIBUTING.rst file for how to force a rebuild.

Closes #198 