### PR TITLE
Add prereqs for make docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,10 +48,14 @@ Ready to contribute? Here's how to set up `earthpy` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that tests pass, and examples run::
+5. When you're done making changes, check that tests pass, docs build, and examples run::
 
     $ pytest --doctest-modules
     $ make docs
+
+By default ``make docs`` will only rebuild the documentation if source
+files (e.g., .py or .rst files) have changed. To force a rebuild, use 
+``make -B docs``.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-docs: ## generate Sphinx HTML documentation, including API docs
+docs: docs/*.rst docs/conf.py docs/Makefile earthpy *.rst ## generate html docs
 	rm -f docs/earthpy.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -H "API reference" -o docs/ earthpy earthpy/tests earthpy/example-data


### PR DESCRIPTION
This PR adds prerequisites to the recipe for making docs, so that the command make docs with execute only when necessary (when files in the prerequisites have changed). This also adds a smidgen more information to the CONTRIBUTING.rst file for how to force a rebuild.

@lwasser have a look at the changes to Makefile here, which will ensure that Make behaves in the way that we want (only rebuilding docs when necessary).

Closes #198 
