### PR TITLE
Adding more info on deployment, doctest, and plots 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -132,7 +132,7 @@ e.g.,::
     .. plot::
 
        >>> import matplotlib.pyplot as plt
-       >>> plt.plot([1,2,3], [4,5,6])
+       >>> plt.plot([1, 2, 3], [4, 5, 6])
 
 
 Style

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -176,7 +176,7 @@ This will increment the version according to a major release (e.g., 0.1.0 to
 
 
 Bumpversion updates the version number throughout the
-package, and generate a git commit along with an associated git tag for the
+package, and generates a git commit along with an associated git tag for the
 new version.
 For more on bumpversion, see: https://github.com/peritus/bumpversion
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,10 +53,6 @@ Ready to contribute? Here's how to set up `earthpy` for local development.
     $ pytest --doctest-modules
     $ make docs
 
-By default ``make docs`` will only rebuild the documentation if source
-files (e.g., .py or .rst files) have changed. To force a rebuild, use 
-``make -B docs``.
-
 6. Commit your changes and push your branch to GitHub::
 
     $ git add .
@@ -90,6 +86,7 @@ When submitting a pull request:
   So be sure that any ``.rst`` file submissions are properly formatted and
   tests are passing.
 
+
 Documentation Updates
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -100,8 +97,46 @@ that our documentation files are in
 format and format your pull request
 accordingly.
 
+To build the documentation, use the command::
+
+    $ make docs
+
+By default ``make docs`` will only rebuild the documentation if source
+files (e.g., .py or .rst files) have changed. To force a rebuild, use
+``make -B docs``.
+You can preview the generated documentation by opening
+``docs/_build/html/index.html`` in a web browser.
+
+Earthpy uses `doctest
+<https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html>`_ to test
+code in the documentation, which includes docstrings in earthpy's modules, and
+code chunks in the reStructuredText source files.
+This enables the actual output of code examples to be checked against expected
+output.
+When the output of an example is not always identical (e.g., the
+memory address of an object), use an `ellipsis
+<https://docs.python.org/3.6/library/doctest.html#doctest.ELLIPSIS>`_
+(``...``) to match any substring of the actual output, e.g.:
+
+.. code-block:: python
+
+  >>> print(list(range(20)))
+  [0, 1, ..., 18, 19]
+
+Earthpy also uses the `Matplotlib plot directive
+<https://matplotlib.org/devel/plot_directive.html>`_ in the documentation to
+generate figures.
+To include a figure in an example, prefix the example with ``.. plot::``,
+e.g.,::
+
+    .. plot::
+
+       >>> import matplotlib.pyplot as plt
+       >>> plt.plot([1,2,3], [4,5,6])
+
+
 Style
------
+~~~~~
 
 - ``Earthpy`` currently only supports Python 3 (3.2+). Please test code locally
   in Python 3 when possible (all supported versions will be automatically
@@ -131,10 +166,25 @@ Deploying
 ~~~~~~~~~
 
 A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed, then run:
+Make sure all your changes are committed, then run::
 
-$ bumpversion patch # possible: major / minor / patch
-$ git push
-$ git push --tags
+    $ bumpversion patch # possible: major / minor / patch
 
-Travis will then deploy to PyPI if tests pass.
+This will increment the version according to a major release (e.g., 0.1.0 to
+1.0.0), a minor release (e.g., 0.1.0 to 0.2.0), or a patch (e.g., 0.1.0 to
+0.1.1), following the guidelines for semantic versioning: https://semver.org/.
+
+
+Bumpversion updates the version number throughout the
+package, and generate a git commit along with an associated git tag for the
+new version.
+For more on bumpversion, see: https://github.com/peritus/bumpversion
+
+To deploy earthpy, push the commit and the version tags::
+
+    $ git push
+    $ git push --tags
+
+Travis will then deploy to PyPI if the build succeeds.
+Travis will only deploy to PyPI on tagged commits, so remember to push the tags.
+Once that is done, create a release on GitHub for the new version.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-docs: docs/*.rst docs/conf.py docs/Makefile earthpy *.rst ## generate html docs
+docs: docs/*.rst docs/conf.py docs/Makefile earthpy/*.py *.rst ## generate html docs
 	rm -f docs/earthpy.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -H "API reference" -o docs/ earthpy earthpy/tests earthpy/example-data

--- a/earthpy/plot.py
+++ b/earthpy/plot.py
@@ -47,9 +47,9 @@ def colorbar(mapobj, size="3%", pad=0.09, aspect=20):
         ...     dem = src.read()
         ...     fig, ax = plt.subplots(figsize = (10, 5))
         >>> im = ax.imshow(dem.squeeze())
-        >>> ep.colorbar(im)  #doctest: +ELLIPSIS
+        >>> ep.colorbar(im)
         <matplotlib.colorbar.Colorbar object at 0x...>
-        >>> ax.set(title="Rocky Mountain National Park DEM") #doctest: +ELLIPSIS
+        >>> ax.set(title="Rocky Mountain National Park DEM")
         [Text(...'Rocky Mountain National Park DEM')]
         >>> ax.set_axis_off()
         >>> plt.show()
@@ -113,7 +113,7 @@ def plot_bands(
         >>> with rio.open(path_to_example('rmnp-rgb.tif')) as src:
         ...     ep.plot_bands(src.read(),
         ...                   title=titles,
-        ...                   figsize=(8, 3)) #doctest: +ELLIPSIS
+        ...                   figsize=(8, 3))
         (<Figure size ... with 3 Axes>, ...)
     """
 
@@ -224,7 +224,7 @@ def plot_rgb(
         >>> from earthpy.io import path_to_example
         >>> with rio.open(path_to_example('rmnp-rgb.tif')) as src:
         ...     img_array = src.read()
-        >>> ep.plot_rgb(img_array) #doctest: +ELLIPSIS
+        >>> ep.plot_rgb(img_array)
         (<Figure size 1000x1000 with 1 Axes>, ...)
 
     """
@@ -319,7 +319,7 @@ def hist(
         ...     colors=['r', 'g', 'b'],
         ...     title=['Red', 'Green', 'Blue'],
         ...     cols=3,
-        ...     figsize=(8, 3)) #doctest: +ELLIPSIS
+        ...     figsize=(8, 3))
         (<Figure size 800x300 with 3 Axes>, ...)
     """
 

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -40,7 +40,7 @@ def extent_to_json(ext_obj):
     >>> import earthpy.spatial as es
     >>> from earthpy.io import path_to_example
     >>> rmnp = gpd.read_file(path_to_example('rmnp.shp'))
-    >>> es.extent_to_json(rmnp) #doctest: +ELLIPSIS
+    >>> es.extent_to_json(rmnp)
     {'type': 'Polygon', 'coordinates': (((-105.4935937, 40.1580827), ...),)}
     """
 
@@ -246,7 +246,7 @@ def _stack_bands(sources, write_raster=False, dest=None):
             Numpy array generated from the stacked array combining all
             bands that were provided in the list.
         ret_prof : rasterio profile
-            Updated rasterio spatial metadata object updated to represent 
+            Updated rasterio spatial metadata object updated to represent
             the number of layers in the stack
     """
 
@@ -459,7 +459,7 @@ def hillshade(arr, azimuth=30, angle_altitude=30):
         >>> print(squeezed_dem.shape)
         (187, 152)
         >>> shade = es.hillshade(squeezed_dem)
-        >>> plt.imshow(shade) #doctest: +ELLIPSIS
+        >>> plt.imshow(shade)
         <matplotlib.image.AxesImage object at 0x...>
     """
     azimuth = 360.0 - azimuth


### PR DESCRIPTION
This PR adds to our contributing guidelines more detail about deployment, using doctest, and using the Matplotlib plot directive. Solves #222 and #196. 

It also removes the ELLIPSIS calls, which were redundant (doctest enables the use of `...` by default), which results in cleaner examples. 

@lwasser please have a look and see what you think!