### PR TITLE
Use setuptools in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ parts/
 sdist/
 var/
 wheels/
+pip-wheel-metadata/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from os import path
-from distutils.core import setup
+from setuptools import setup
 
 
 DISTNAME = "earthpy"
@@ -25,6 +25,7 @@ if __name__ == "__main__":
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/markdown",
         version=VERSION,
+        packages=['earthpy'],
         install_requires=[
             "tqdm",
             "pandas",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-import os
-import setuptools
-from numpy.distutils.core import setup
+from os import path
+from distutils.core import setup
 
 
 DISTNAME = "earthpy"
@@ -10,21 +9,7 @@ MAINTAINER_EMAIL = "leah.wasser@colorado.edu"
 VERSION = "VERSION='0.6.0'"
 
 
-def configuration(parent_package="", top_path=None):
-    if os.path.exists("MANIFEST"):
-        os.remove("MANIFEST")
-
-    from numpy.distutils.misc_util import Configuration
-
-    config = Configuration(None, parent_package, top_path)
-    config.add_subpackage("earthpy")
-
-    return config
-
-
 # read the contents of your README file
-from os import path
-
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
@@ -32,7 +17,6 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 if __name__ == "__main__":
     setup(
-        configuration=configuration,
         name=DISTNAME,
         maintainer=MAINTAINER,
         include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/markdown",
         version=VERSION,
-        packages=['earthpy'],
+        packages=["earthpy"],
         install_requires=[
             "tqdm",
             "pandas",


### PR DESCRIPTION
This PR removes the installation dependency on numpy's distutils module, and instead uses setuptools as recommended by the PSF: https://packaging.python.org/guides/tool-recommendations/

The use of numpy's distutils module seems to be unnecessary for earthpy, because it does not use the specialized features in `numpy.distutils` (e.g., the ability to handle Fortan source files as described here: https://docs.scipy.org/doc/numpy-1.14.0/f2py/distutils.html)

Locally, this solved  #206 for me. I'm opening this as a draft to see how the builds shake out on Travis. I also would like to have other folks (@lwasser and @joemcglinchy if you have time) test this on Mac and Windows if possible, to make sure that the installation still proceeds as expected given the changes to `setup.py`.
