### PR TITLE
Use tox and AppVeyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ earthpy/testing.py
 # OS stuff
 .DS_Store
 earthpy/tests/test_ignored_script.py
+
+pip-wheel-metadata/
+earthpy-dev/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,21 @@
-language: python
-python:
-- 3.6
-cache: pip
-before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- sleep 3
-install:
-- sudo apt-get update
-- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- conda env create -f environment.yml
-- source activate earthpy-dev
-- conda list
-- python setup.py install
-- pip install -r dev-requirements.txt
-- pip install black
-script:
-  - pytest --doctest-modules --cov=earthpy --rootdir earthpy
-  - make docs
-  - black --check --verbose .
+dist: xenial
 
-after_success:
-- codecov
+language: python
+
+python:
+- "3.5"
+- "3.6"
+- "3.7"
+
+before_install:
+  - sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable --yes
+  - sudo apt-get update
+  - sudo apt-get install -y libspatialindex-dev libgdal-dev python3-tk
+
+install: pip install -U tox-travis
+
+script: tox
+
 deploy:
   provider: pypi
   user: lwasser

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,16 +1,14 @@
+=======================
 Contributing Guidelines
 =======================
 
-We welcome contributions to ``earthpy``. They are more likely to
+We welcome contributions to EarthPy. They are more likely to
 be accepted if they follow the guidelines below.
 
 At this stage of development, we are developing a set of
 usable wrapper functions that help make working with earth
 systems data easier. We are open to new functionality but are currently
 trying to ensure our package is stable, operational and well documented.
-
-Edits & Updates
-~~~~~~~~~~~~~~~
 
 When submitting a change to the repository, please first create an issue that
 covers the item that you'd like to change, update or enhance. Once a discussion
@@ -24,42 +22,91 @@ If you are proposing a feature:
 
 
 Get Started!
-------------
+============
 
-Ready to contribute? Here's how to set up `earthpy` for local development.
+Ready to contribute? Here's how to set up EarthPy for local development.
 
-1. Fork the `earthpy` repo on GitHub.
-2. Clone your fork locally::
+1. Fork the repository on GitHub
+--------------------------------
+
+To create your own copy of the repository on GitHub, navigate to the
+`earthlab/earthpy <https://github.com/earthlab/earthpy>`_ repository
+and click the **Fork** button in the top-right corner of the page.
+
+2. Clone your fork locally
+--------------------------
+
+Use ``git clone`` to get a local copy of your EarthPy repository on your
+local filesystem::
 
     $ git clone git@github.com:your_name_here/earthpy.git
-
-3. Set up your fork for local development with conda::
-
     $ cd earthpy/
-    $ conda env create -f environment.yml
+
+3. Set up your fork for local development
+-----------------------------------------
+
+Create an environment
+^^^^^^^^^^^^^^^^^^^^^
+
+Using conda::
+
+    $ conda create -n earthpy-dev python=3.7
     $ source activate earthpy-dev
+
+Or, using virtualenv::
+
+    $ virtualenv earthpy-dev
+    $ source earthpy-dev/bin/activate
+
+Install the package
+^^^^^^^^^^^^^^^^^^^
+
+Once the environment is activated, install EarthPy in editable
+mode, along with the development requirements and pre-commit hooks::
+
     $ pip install -e .
     $ pip install -r dev-requirements.txt
     $ pre-commit install
 
-4. Create a branch for local development::
+4. Create a branch for local development
+----------------------------------------
+
+Use the ``git checkout`` command to create your own branch, and pick a name
+that describes the changes that you are making::
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
-   Now you can make your changes locally.
+Now you can make your changes locally.
 
-5. When you're done making changes, check that tests pass, docs build, and examples run::
+5. Test the package
+-------------------
 
-    $ pytest --doctest-modules
+Ensure that the tests pass, and the documentation builds successfully::
+
+    $ pytest
     $ make docs
 
-6. Commit your changes and push your branch to GitHub::
+To test against multiple versions of python, you can use tox.
+Note that if you are using conda - even with virtualenv - you may need to
+install tox-conda (via ``pip install tox-conda``) for tox to work correctly.
+Otherwise, you may get ``InterpreterNotFound`` errors when running tox.
+
+Running tox is as simple as::
+
+    $ tox
+
+6. Commit and push your changes
+-------------------------------
+
+Once you are sure that all tests are passing, you can commit your changes
+and push to GitHub::
 
     $ git add .
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+7. Submit a pull request on GitHub
+----------------------------------
 
 When submitting a pull request:
 
@@ -88,12 +135,13 @@ When submitting a pull request:
 
 
 Documentation Updates
-~~~~~~~~~~~~~~~~~~~~~
+=====================
 
-Improving the documentation and testing for code already in ``earthpy``
+Improving the documentation and testing for code already in EarthPy
 is a great way to get started if you'd like to make a contribution. Please note
 that our documentation files are in
-`ReStructuredText (.rst) <http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+`ReStructuredText (.rst)
+<http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
 format and format your pull request
 accordingly.
 
@@ -109,7 +157,7 @@ You can preview the generated documentation by opening
 
 Earthpy uses `doctest
 <https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html>`_ to test
-code in the documentation, which includes docstrings in earthpy's modules, and
+code in the documentation, which includes docstrings in EarthPy's modules, and
 code chunks in the reStructuredText source files.
 This enables the actual output of code examples to be checked against expected
 output.
@@ -135,14 +183,14 @@ e.g.,::
        >>> plt.plot([1, 2, 3], [4, 5, 6])
 
 
-Style
-~~~~~
+Code style
+==========
 
-- ``Earthpy`` currently only supports Python 3 (3.2+). Please test code locally
+- EarthPy currently only supports Python 3 (3.5+). Please test code locally
   in Python 3 when possible (all supported versions will be automatically
   tested on Travis CI).
 
-- ``Earthpy`` uses a pre-commit hook that runs the black code autoformatter.
+- EarthPy uses a pre-commit hook that runs the black code autoformatter.
   Be sure to execute `pre-commit install` as described above, which will cause
   black to autoformat code prior to commits. If this step is skipped, black
   may cause build failures on Travis CI due to formatting issues.
@@ -157,13 +205,14 @@ Style
     - Class definitions should use camel case - example: ``ClassNameHere`` .
 
 - Imports should be grouped with standard library imports first,
-  3rd-party libraries next, and ``earthpy`` imports third following PEP 8
+  3rd-party libraries next, and EarthPy imports third following PEP 8
   standards. Within each grouping, imports should be alphabetized. Always use
   absolute imports when possible, and explicit relative imports for local
   imports when necessary in tests.
 
+
 Deploying
-~~~~~~~~~
+=========
 
 A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed, then run::
@@ -180,7 +229,7 @@ package, and generates a git commit along with an associated git tag for the
 new version.
 For more on bumpversion, see: https://github.com/peritus/bumpversion
 
-To deploy earthpy, push the commit and the version tags::
+To deploy EarthPy, push the commit and the version tags::
 
     $ git push
     $ git push --tags

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![DOI](https://zenodo.org/badge/122149160.svg)](https://zenodo.org/badge/latestdoi/122149160)
 [![Build Status](https://travis-ci.org/earthlab/earthpy.svg?branch=master)](https://travis-ci.org/earthlab/earthpy)
+[![Build status](https://ci.appveyor.com/api/projects/status/xgf5g4ms8qhgtp21?svg=true)](https://ci.appveyor.com/project/earthlab/earthpy)
 [![codecov](https://codecov.io/gh/earthlab/earthpy/branch/master/graph/badge.svg)](https://codecov.io/gh/earthlab/earthpy)
 [![Docs build](https://readthedocs.org/projects/earthpy/badge/?version=latest)](https://earthpy.readthedocs.io/en/latest/?badge=latest)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://img.shields.io/badge/code%20style-black-000000.svg)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+# 99% borrowed from geopandas
+
+matrix:
+  fast_finish: true     # immediately finish build once one of the jobs fails.
+
+environment:
+  matrix:
+    - PYTHON_VERSION: "3.6"
+      MINICONDA: C:\Miniconda36-x64
+
+build: false
+
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+
+install:
+  # cancel older builds for the same PR
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+
+  # set up environment
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set show_channel_urls true --set changeps1 no
+  - conda update -q conda
+  - conda config --add channels conda-forge
+  - conda info -a
+  - conda env create -f environment.yml
+  - activate earthpy-dev
+  - pip install -r dev-requirements.txt
+
+test_script:
+  - conda list
+  - pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,9 @@
 bumpversion
+codecov
 pre-commit
+pytest
+pytest-cov
 sphinx==1.8.0
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme
+tox

--- a/earthpy/tests/test_plot_rgb.py
+++ b/earthpy/tests/test_plot_rgb.py
@@ -146,7 +146,11 @@ def test_stretch_output_scaled(rgb_image):
     """
     arr, _ = rgb_image
     stretch_vals = list(range(10))
-    axs = [plot_rgb(arr, stretch=True, str_clip=v)[1] for v in stretch_vals]
+    axs = list()
+    for v in stretch_vals:
+        f, ax = plot_rgb(arr, stretch=True, str_clip=v)
+        axs.append(ax)
+        plt.close(f)
     mean_vals = np.array([ax.get_images()[0].get_array().mean() for ax in axs])
     n_unique_means = np.unique(mean_vals).shape[0]
     assert n_unique_means == len(stretch_vals)

--- a/earthpy/utils.py
+++ b/earthpy/utils.py
@@ -2,7 +2,6 @@ import os
 import numpy as np
 import rasterio as rio
 from shapely.geometry import Polygon, mapping
-from tqdm import tqdm
 
 # This should be moved to the new package that handles data download
 # and the website build potentially

--- a/environment.yml
+++ b/environment.yml
@@ -3,14 +3,9 @@ channels:
   - conda-forge
 dependencies:
   # Core scientific python
-  - codecov
   - numpy
   - matplotlib
   - python=3.6
-  - pyqt
-  - pytest
-  - pytest-cov
-  - seaborn
 
   # Geo stuff
   - geopy
@@ -27,5 +22,3 @@ dependencies:
       # Utilities
       - download
       - mne
-      - sklearn
-      - tqdm

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-import os
-import setuptools
-from numpy.distutils.core import setup
+from os import path
+from setuptools import setup
 
 
 DISTNAME = "earthpy"
@@ -10,21 +9,7 @@ MAINTAINER_EMAIL = "leah.wasser@colorado.edu"
 VERSION = "VERSION='0.6.0'"
 
 
-def configuration(parent_package="", top_path=None):
-    if os.path.exists("MANIFEST"):
-        os.remove("MANIFEST")
-
-    from numpy.distutils.misc_util import Configuration
-
-    config = Configuration(None, parent_package, top_path)
-    config.add_subpackage("earthpy")
-
-    return config
-
-
 # read the contents of your README file
-from os import path
-
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
@@ -32,7 +17,6 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 if __name__ == "__main__":
     setup(
-        configuration=configuration,
         name=DISTNAME,
         maintainer=MAINTAINER,
         include_package_data=True,
@@ -41,13 +25,14 @@ if __name__ == "__main__":
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/markdown",
         version=VERSION,
+        packages=["earthpy"],
         install_requires=[
-            "tqdm",
             "pandas",
-            "numpy",
+            "numpy>=1.14.0",
             "geopandas",
             "matplotlib>=2.0.0",
             "rasterio",
+            "Rtree>=0.8",
             "download",
             "scikit-image",
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py35, py36, py37, black, docs
+
+[travis]
+python =
+  3.5: py35
+  3.6: py36
+  3.7: py37, docs, black
+
+[testenv]
+deps =
+    -r{toxinidir}/dev-requirements.txt
+whitelist_externals = pytest
+commands =
+    pytest --basetemp={envtmpdir} --cov=earthpy
+    codecov
+
+[testenv:black]
+deps = black
+commands = black --check --verbose earthpy
+
+[testenv:docs]
+whitelist_externals = make
+commands =
+  pip install .
+  make -B docs


### PR DESCRIPTION
This tests earthpy against python 3.5 through 3.7 using tox, and also uses AppVeyor to test earthpy on Windows. Last, this updates documentation for development using conda or virtualenv and testing of multiple python versions with tox.

@lwasser and @joemcglinchy please take the updated development instructions in `CONTRIBUTING.rst` for a test drive. I will be curious to see what issues come up, especially on Windows. I'm opening this as a draft PR until we get some more eyes on it.

Solves the hardest part of #228 - testing on Windows (but we should leave that issue open until we get some tests in CI for macOS). Closes #213.
