### PR TITLE
Add URL to Rim Fire data

### DIFF
--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -60,6 +60,11 @@ DATA_URLS = {
         ".",
         "zip",
     ),
+        "california-rim-fire": (
+        "https://ndownloader.figshare.com/files/14419310",
+        ".",
+        "zip",
+    ),
 }
 
 ALLOWED_FILE_TYPES = ["zip", "tar", "tar.gz", "file"]

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -60,7 +60,7 @@ DATA_URLS = {
         ".",
         "zip",
     ),
-        "california-rim-fire": (
+    "california-rim-fire": (
         "https://ndownloader.figshare.com/files/14419310",
         ".",
         "zip",


### PR DESCRIPTION
@lwasser  This update adds the URL to the Rim Fire data hosted on Figshare.