### PR TITLE
Add code of conduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-# EarthPy release notes
+# EarthPy Release Notes
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+* Added a code of conduct (@mbjoseph, #27)
 
 ## [0.6.2] - 2019-02-19
 We have made significant changes in preparation for a 1.0 release

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# EarthPy Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at Leah.Wasser@colorado.edu. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,8 +1,9 @@
 Contributing Guidelines
 =======================
 
-We welcome contributions to ``earthpy``. They are more likely to
-be accepted if they follow the guidelines below.
+We welcome contributions of many kinds to ``earthpy``.
+When contributing, please follow the guidelines below and adhere to the
+`EarthPy Code of Conduct <code-of-conduct.html>`_.
 
 At this stage of development, we are developing a set of
 usable wrapper functions that help make working with earth

--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../CODE_OF_CONDUCT.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = "Earthpy"
+project = "EarthPy"
 copyright = "2018, Earth Lab"
 author = "Earth Lab"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ EarthPy User Guide
    contributors
    modules
    change-log
+   code-of-conduct
 
 Indices and Tables
 ==================


### PR DESCRIPTION
This PR adds a code of conduct based on http://contributor-covenant.org and links to it from the CONTRIBUTING guidelines.

This PR also has some capitalization corrections in the docs to consistently use title case for page names. @lwasser please take a look when you get a chance and let me know if this is what you had in mind, or if you think we should make any changes to the code of conduct. 

Closes #27.