### PR TITLE
Remove line for including package data to fix PyPI install issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ if __name__ == "__main__":
     setup(
         name=DISTNAME,
         maintainer=MAINTAINER,
-        include_package_data=True,
         maintainer_email=MAINTAINER_EMAIL,
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
Currently because of the way setuptools distributes data and uses the `include_package_data` argument, installing earthpy from PyPI does not seem to consistently include the example data directory as described in https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distribute. 

This PR solves #250 and #245, and should ensure that installing earthpy with pip includes example data.