### PR TITLE
Test EarthlabData class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ earthpy/ignored_script.py
 # OS stuff
 .DS_Store
 earthpy/tests/test_ignored_script.py
+earthpy/tests/cassettes/
+*.ipynb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Closing plots in tests (@lwasser #257)
 * Added a code of conduct (@mbjoseph, #27)
+* Added tests for EarthlabData class (@mbjoseph, #37)
 
 ## [0.6.2] - 2019-02-19
 We have made significant changes in preparation for a 1.0 release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Closing plots in tests (@lwasser #257)
 * Added a code of conduct (@mbjoseph, #27)
 
 ## [0.6.2] - 2019-02-19

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 bumpversion
 m2r
 pre-commit
+pytest-vcr
 sphinx==1.8.0
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme

--- a/earthpy/__init__.py
+++ b/earthpy/__init__.py
@@ -1,17 +1,11 @@
 """Utility functions for the working with spatial data."""
 
-from .io import EarthlabData  # , list_files
-from download import download
+from pkg_resources import resource_string
 import json
-import os.path as op
-from . import utils, spatial
+from .io import EarthlabData
+
 
 data = EarthlabData()
-
-# This EPSG mapping converted from:
-# https://github.com/jswhit/pyproj/blob/master/lib/pyproj/data/epsg
-
-from pkg_resources import resource_string
 
 epsg = json.loads(
     resource_string("earthpy", "example-data/epsg.json").decode("utf-8")

--- a/earthpy/__init__.py
+++ b/earthpy/__init__.py
@@ -2,10 +2,10 @@
 
 from pkg_resources import resource_string
 import json
-from .io import EarthlabData
+from .io import Data
 
 
-data = EarthlabData()
+data = Data()
 
 epsg = json.loads(
     resource_string("earthpy", "example-data/epsg.json").decode("utf-8")

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -234,44 +234,6 @@ class EarthlabData(object):
         return data_paths
 
 
-# Potential functionality for website build.
-# Move to new utils package
-
-
-def list_files(path, depth=3):
-    """
-    List files in a directory up to a specified depth.
-
-    Parameters
-    ----------
-    path : str
-        A path to a folder whose contents you want to list recursively.
-    depth : int
-        The depth of files / folders you want to list inside of ``path``.
-    """
-    if not os.path.isdir(path):
-        raise ValueError("path: {} is not a directory".format(path))
-    depth_str_base = "  "
-    if not path.endswith(os.sep):
-        path = path + os.sep
-
-    for ii, (i_path, folders, files) in enumerate(os.walk(path)):
-        folder_name = op.basename(i_path)
-        path_wo_base = i_path.replace(path, "")
-        this_depth = len(path_wo_base.split("/"))
-        if this_depth > depth:
-            continue
-
-        # Define the string for this level
-        depth_str = depth_str_base * this_depth
-        print(depth_str + folder_name)
-
-        if this_depth + 1 > depth:
-            continue
-        for ifile in files:
-            print(depth_str + depth_str_base + ifile)
-
-
 def path_to_example(dataset):
     """ Construct a file path to an example dataset.
 

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -159,9 +159,10 @@ class EarthlabData(object):
 
         if key is not None:
             if key not in DATA_URLS:
+                pretty_keys = ", ".join(repr(k) for k in self.data_keys)
                 raise KeyError(
                     "Key '" + key + "' not found in earthpy.io.DATA_URLS. "
-                    "Choose one of {}".format(self.data_keys)
+                    "Choose one of: {}".format(pretty_keys)
                 )
 
             this_data = DATA_URLS[key]
@@ -186,7 +187,7 @@ class EarthlabData(object):
                 fname = os.path.splitext(fname)[0]
 
             this_data = (url, fname, file_type)
-            this_root = op.join(self.path, "unsorted")
+            this_root = op.join(self.path, "earthpy-downloads")
 
         if not isinstance(this_data, list):
             this_data = [this_data]

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -128,7 +128,6 @@ class EarthlabData(object):
         url : str
             A URL to fetch into the data directory. Use this for ad-hoc dataset
             downloads. Note: ``key`` and ``url`` are mutually exclusive.
-            Currently this is only tested against figshare URLs.
         replace : bool
             Whether to replace the data for this key if it is
             already downloaded.

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -90,15 +90,14 @@ class EarthlabData(object):
     --------
     List datasets that are available for download, using default object:
 
-        >>> import earthpy
-        >>> earthpy.data
+        >>> import earthpy as et
+        >>> et.data
         Available Datasets: ['california-rim-fire', ...]
 
-    Specify a directory when instantiating a new object:
+    Specify a custom directory for data downloads:
 
-        >>> import earthpy.io as eio
-        >>> data = eio.EarthlabData('.')
-        >>> data
+        >>> et.data.path = "."
+        >>> et.data
         Available Datasets: ['california-rim-fire', ...]
     """
 
@@ -141,12 +140,12 @@ class EarthlabData(object):
         --------
         Download a dataset using a key:
 
-            >>> earthpy.data.get_data('california-rim-fire') # doctest: +SKIP
+            >>> et.data.get_data('california-rim-fire') # doctest: +SKIP
 
         Or, download a dataset using a figshare URL:
 
             >>> url = 'https://ndownloader.figshare.com/files/12395030'
-            >>> earthpy.data.get_data(url=url) # doctest: +SKIP
+            >>> et.data.get_data(url=url)  # doctest: +SKIP
 
         """
         if key is not None and url is not None:
@@ -161,15 +160,15 @@ class EarthlabData(object):
         if key is not None:
             if key not in DATA_URLS:
                 raise KeyError(
-                    "Key " + key + " not found in earthpy.io.DATA_URLS. "
-                    "{}\nChoose one of {}".format(key, DATA_URLS.keys())
+                    "Key '" + key + "' not found in earthpy.io.DATA_URLS. "
+                    "Choose one of {}".format(self.data_keys)
                 )
 
             this_data = DATA_URLS[key]
             this_root = op.join(self.path, key)
 
         if url is not None:
-            with requests.get(url) as r:
+            with requests.head(url) as r:
                 if "content-disposition" in r.headers.keys():
                     content = r.headers["content-disposition"]
                     fname = re.findall("filename=(.+)", content)[0]

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -1,6 +1,5 @@
 """File Input/Output utilities."""
-## This module will move to a new module for downloading data
-## and building lessons
+
 
 import os
 import os.path as op
@@ -72,7 +71,7 @@ HOME = op.join(op.expanduser("~"))
 DATA_NAME = op.join("earth-analytics", "data")
 
 
-class EarthlabData(object):
+class Data(object):
     """
     Data storage and retrieval functionality for Earthlab.
 

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -161,7 +161,7 @@ class EarthlabData(object):
         if key is not None:
             if key not in DATA_URLS:
                 raise KeyError(
-                    "Key " + key + " not found in earthlab.io.DATA_URLS. "
+                    "Key " + key + " not found in earthpy.io.DATA_URLS. "
                     "{}\nChoose one of {}".format(key, DATA_URLS.keys())
                 )
 

--- a/earthpy/tests/test_io.py
+++ b/earthpy/tests/test_io.py
@@ -11,7 +11,7 @@ import earthpy.io as eio
 
 @pytest.fixture
 def eld(tmpdir):
-    return eio.EarthlabData(path=tmpdir)
+    return eio.Data(path=tmpdir)
 
 
 def test_invalid_datasets_raise_errors():

--- a/earthpy/tests/test_io.py
+++ b/earthpy/tests/test_io.py
@@ -178,6 +178,13 @@ def test_arbitrary_url_zip_download(eld):
     assert dir_has_contents
 
 
+@pytest.mark.vcr()
+def test_url_download_w_content_disposition(eld):
+    """ Test arbitrary URL download with content-disposition. """
+    file = eld.get_data(url="https://ndownloader.figshare.com/files/14555681")
+    assert os.path.isfile(file)
+
+
 def test_invalid_data_type(eld):
     """ Raise errors for invalid data types. """
     eio.DATA_URLS["invalid-data-type"] = [

--- a/earthpy/tests/test_io.py
+++ b/earthpy/tests/test_io.py
@@ -1,34 +1,40 @@
-""" Tests for example data. """
+""" Tests for io module. """
 
 import os
+import requests
 import pytest
 import numpy as np
 import rasterio as rio
 import geopandas as gpd
-from earthpy.io import path_to_example
+import earthpy.io as eio
+
+
+@pytest.fixture
+def ELD(tmpdir):
+    return eio.EarthlabData(path=tmpdir)
 
 
 def test_invalid_datasets_raise_errors():
     """ Raise errors when users provide nonexistent datasets. """
     with pytest.raises(KeyError):
-        path_to_example("Non-existent dataset")
+        eio.path_to_example("Non-existent dataset")
 
 
 def test_missing_datasets_raise_errors():
     """ Raise errors when users forget to provide a dataset. """
     with pytest.raises(KeyError):
-        path_to_example("")
+        eio.path_to_example("")
 
 
 def test_valid_datasets_get_returned():
     """ If users give a valid dataset name, return a valid path. """
-    epsg_path = path_to_example("epsg.json")
+    epsg_path = eio.path_to_example("epsg.json")
     assert os.path.isfile(epsg_path)
 
 
 def test_rgb():
     """ Check assumptions about rgb satellite imagery over RMNP. """
-    with rio.open(path_to_example("rmnp-rgb.tif")) as src:
+    with rio.open(eio.path_to_example("rmnp-rgb.tif")) as src:
         rgb = src.read()
         rgb_crs = src.crs
     assert rgb.shape == (3, 373, 485)
@@ -37,33 +43,134 @@ def test_rgb():
 
 def test_rgb_single_channels():
     """ Check assumptions about single channel R, G, and B images. """
-    fnames = [path_to_example(f) for f in ["red.tif", "green.tif", "blue.tif"]]
+    tif_names = [color + ".tif" for color in ["red", "green", "blue"]]
+    fnames = [eio.path_to_example(f) for f in tif_names]
     rgb_parts = list()
     for f in fnames:
         with rio.open(f) as src:
             rgb_parts.append(src.read())
             assert str(src.crs) == rio.crs.CRS.from_epsg(4326)
 
-    with rio.open(path_to_example("rmnp-rgb.tif")) as src:
+    with rio.open(eio.path_to_example("rmnp-rgb.tif")) as src:
         assert np.array_equal(src.read(), np.concatenate(rgb_parts))
 
 
 def test_colorado_counties():
     """ Check assumptions about county polygons. """
-    counties = gpd.read_file(path_to_example("colorado-counties.geojson"))
+    counties = gpd.read_file(eio.path_to_example("colorado-counties.geojson"))
     assert counties.shape == (64, 13)
     assert counties.crs == {"init": "epsg:4326"}
 
 
 def test_colorado_glaciers():
     """ Check assumptions about glacier point locations. """
-    glaciers = gpd.read_file(path_to_example("colorado-glaciers.geojson"))
+    glaciers = gpd.read_file(eio.path_to_example("colorado-glaciers.geojson"))
     assert glaciers.shape == (134, 2)
     assert glaciers.crs == {"init": "epsg:4326"}
 
 
 def test_continental_divide_trail():
     """ Check assumptions about Continental Divide Trail path. """
-    cdt = gpd.read_file(path_to_example("continental-div-trail.geojson"))
+    cdt = gpd.read_file(eio.path_to_example("continental-div-trail.geojson"))
     assert cdt.shape == (1, 2)
     assert cdt.crs == {"init": "epsg:4326"}
+
+
+""" Tests for the EarthlabData class. """
+
+# Add links to very small test data on figshare to the data urls
+eio.DATA_URLS["little-text-file"] = [
+    ("https://ndownloader.figshare.com/files/14555681", "abc.txt", "file")
+]
+
+eio.DATA_URLS["little-zip-file"] = [
+    ("https://ndownloader.figshare.com/files/14555684", ".", "zip")
+]
+
+
+@pytest.mark.vcr()
+def test_urls_are_valid():
+    """ Test responses for each dataset to ensure valid URLs. """
+    for key in eio.DATA_URLS:
+        dataset = eio.DATA_URLS[key]
+        if not isinstance(dataset, list):
+            dataset = [dataset]
+        for url, name, kind in dataset:
+            r = requests.get("http://www.example.com")
+            assert r.status_code == 200
+
+
+def test_key_and_url_set_simultaneously(ELD):
+    """ Only key or url should be set, not both. """
+    with pytest.raises(ValueError, match="can not both be set at the same"):
+        ELD.get_data(key="foo", url="bar")
+
+
+def test_available_datasets_are_printed(ELD, capsys):
+    """ If no key or url provided, print datasets.
+
+    The output that is printed should be identical to the __repr__ output.
+    Using capsys in pytest provides a way to capture stdout/stderr output.
+    
+    """
+    ELD.get_data()
+    printed_output = capsys.readouterr().out
+    print(ELD)
+    repr_output = capsys.readouterr().out
+    assert printed_output == repr_output
+
+
+def test_invalid_dataset_key(ELD):
+    """ Raise errors for unknown dataset keys. """
+    with pytest.raises(KeyError, match="not found in"):
+        ELD.get_data(key="some non-existent key")
+
+
+@pytest.mark.vcr()
+def test_url_download(ELD):
+    """ Test arbitrary URL download. """
+    file = ELD.get_data(url="https://ndownloader.figshare.com/files/14555681")
+    assert os.path.isfile(file)
+
+
+@pytest.mark.vcr()
+def test_valid_download_file(ELD):
+    """ Test that single files get downloaded. """
+    file = ELD.get_data("little-text-file")
+    assert os.path.isfile(file)
+
+
+@pytest.mark.vcr()
+def test_valid_download_zip(ELD):
+    """ Test that zipped files get downloaded and extracted. """
+    dir = ELD.get_data("little-zip-file")
+    assert os.path.isdir(dir)
+    dir_has_contents = len(os.listdir(dir)) > 0
+    assert dir_has_contents
+
+
+@pytest.mark.vcr()
+def test_replace_arg_prevents_overwrite(ELD):
+    """ If replace=True, existing files should not be overwritten. """
+    file1 = ELD.get_data("little-text-file")
+    time_modified1 = os.path.getmtime(file1)
+    file2 = ELD.get_data("little-text-file", replace=False)
+    time_modified2 = os.path.getmtime(file2)
+    assert time_modified1 == time_modified2
+
+
+@pytest.mark.vcr()
+def test_replace_arg_allows_overwrite(ELD):
+    """ If replace=False, existing files should be overwritten. """
+    file1 = ELD.get_data("little-text-file")
+    time_modified1 = os.path.getmtime(file1)
+    file2 = ELD.get_data("little-text-file", replace=True)
+    time_modified2 = os.path.getmtime(file2)
+    assert time_modified1 < time_modified2
+
+
+@pytest.mark.vcr()
+def test_content_disposition_key_error(ELD):
+    """ Raise a KeyError if content-disposition is not found in headers. """
+    with pytest.raises(KeyError, match="content-disposition was not found"):
+        ELD.get_data(url="http://www.google.com/robots.txt")

--- a/earthpy/tests/test_io.py
+++ b/earthpy/tests/test_io.py
@@ -126,13 +126,6 @@ def test_invalid_dataset_key(eld):
 
 
 @pytest.mark.vcr()
-def test_url_download(eld):
-    """ Test arbitrary URL download. """
-    file = eld.get_data(url="https://ndownloader.figshare.com/files/14555681")
-    assert os.path.isfile(file)
-
-
-@pytest.mark.vcr()
 def test_valid_download_file(eld):
     """ Test that single files get downloaded. """
     file = eld.get_data("little-text-file")

--- a/earthpy/tests/test_io.py
+++ b/earthpy/tests/test_io.py
@@ -143,7 +143,7 @@ def test_valid_download_zip(eld):
 
 @pytest.mark.vcr()
 def test_replace_arg_prevents_overwrite(eld):
-    """ If replace=True, existing files should not be overwritten. """
+    """ If replace=False, do not replace existing files. """
     file1 = eld.get_data("little-text-file")
     time_modified1 = os.path.getmtime(file1)
     file2 = eld.get_data("little-text-file", replace=False)
@@ -153,7 +153,7 @@ def test_replace_arg_prevents_overwrite(eld):
 
 @pytest.mark.vcr()
 def test_replace_arg_allows_overwrite(eld):
-    """ If replace=False, existing files should be overwritten. """
+    """ If replace=True, replace existing files. """
     file1 = eld.get_data("little-text-file")
     time_modified1 = os.path.getmtime(file1)
     file2 = eld.get_data("little-text-file", replace=True)

--- a/earthpy/tests/test_plot.py
+++ b/earthpy/tests/test_plot.py
@@ -2,6 +2,9 @@
 
 import numpy as np
 import pytest
+import matplotlib as mpl
+
+mpl.use("TkAgg")
 import matplotlib.pyplot as plt
 import earthpy.plot as ep
 
@@ -15,6 +18,7 @@ def test_arr_parameter():
     """Raise an AttributeError if an array is not provided."""
     with pytest.raises(AttributeError):
         ep.plot_bands(arr=(1, 2))
+    plt.close()
 
 
 def test_num_titles(image_array_2bands):
@@ -32,6 +36,7 @@ def test_num_titles(image_array_2bands):
         ep.plot_bands(
             arr=image_array_2bands, title=["Title1", "Title2", "Title3"]
         )
+    plt.close()
 
 
 def test_num_axes(image_array_2bands):
@@ -109,6 +114,7 @@ def test_colorbar_raises_value_error():
     """Test that a non matbplotlib axis object raises an value error."""
     with pytest.raises(AttributeError, match="requires a matplotlib"):
         ep.colorbar(list())
+    plt.close()
 
 
 """ Hist tests """
@@ -118,6 +124,7 @@ def test_num_plot_titles_mismatch_hist(image_array_2bands):
     """Raise an error if the number of titles != number of bands."""
     with pytest.raises(ValueError, match="number of plot titles"):
         ep.hist(image_array_2bands, title=["One", "too", "many"])
+    plt.close()
 
 
 def test_num_axes_hist(image_array_2bands, basic_image):
@@ -126,6 +133,8 @@ def test_num_axes_hist(image_array_2bands, basic_image):
     assert len(f_1.axes) == 1
     f_2, ax_2 = ep.hist(image_array_2bands)
     assert len(f_2.axes) == 2
+    plt.close(f_1)
+    plt.close(f_2)
 
 
 def test_single_hist_title(basic_image):
@@ -133,6 +142,7 @@ def test_single_hist_title(basic_image):
     custom_title = "Great hist"
     f, ax = ep.hist(basic_image, title=[custom_title])
     assert ax.get_title() == custom_title
+    plt.close(f)
 
 
 def test_multiband_hist_title(image_array_2bands):
@@ -141,6 +151,7 @@ def test_multiband_hist_title(image_array_2bands):
     f, ax = ep.hist(image_array_2bands, title=custom_titles)
     num_plts = image_array_2bands.shape[0]
     assert [f.axes[i].get_title() for i in range(num_plts)] == custom_titles
+    plt.close(f)
 
 
 def test_number_of_hist_bins(basic_image):
@@ -149,6 +160,7 @@ def test_number_of_hist_bins(basic_image):
     for n in n_bins:
         f, ax = ep.hist(basic_image, bins=n)
         assert n == len(ax.patches)
+        plt.close()
 
 
 def test_hist_bbox(basic_image):
@@ -156,6 +168,7 @@ def test_hist_bbox(basic_image):
     f, ax = ep.hist(basic_image, figsize=(50, 3))
     bbox = str(f.__dict__.get("bbox_inches"))
     assert bbox == "Bbox(x0=0.0, y0=0.0, x1=50.0, y1=3.0)"
+    plt.close()
 
 
 def test_hist_color_single_band(basic_image):
@@ -163,6 +176,7 @@ def test_hist_color_single_band(basic_image):
     f, ax = ep.hist(basic_image, colors=["red"])
     facecolor = ax.patches[0].__dict__.get("_original_facecolor")
     assert np.array_equal(facecolor, np.array([1.0, 0.0, 0.0, 1.0]))
+    plt.close(f)
 
 
 def test_hist_color_multi_band(image_array_2bands):
@@ -175,6 +189,7 @@ def test_hist_color_multi_band(image_array_2bands):
     ]
     for i in range(2):
         assert np.array_equal(colors[i], expected_colors[i])
+    plt.close(f)
 
 
 def test_hist_number_of_columns(image_array_2bands):
@@ -183,3 +198,4 @@ def test_hist_number_of_columns(image_array_2bands):
     for n in number_of_columns:
         f, ax = ep.hist(image_array_2bands, cols=n)
         assert [a.numCols for a in ax] == [n] * 2
+        plt.close(f)

--- a/earthpy/tests/test_plot_draw_legend.py
+++ b/earthpy/tests/test_plot_draw_legend.py
@@ -46,7 +46,7 @@ def test_num_titles_classes(binned_array_3bins):
     bins, im_arr_bin = binned_array_3bins
     im_arr_bin[im_arr_bin == 2] = 3
 
-    fig, ax = plt.subplots(figsize=(5, 5))
+    f, ax = plt.subplots(figsize=(5, 5))
     im_ax = ax.imshow(im_arr_bin, cmap="Blues")
 
     with pytest.raises(ValueError):
@@ -58,6 +58,7 @@ def test_num_titles_classes(binned_array_3bins):
         ep.draw_legend(
             im_ax=im_ax, classes=[1, 2, 3], titles=["small", "large"]
         )
+    plt.close(f)
 
 
 def test_stock_legend_titles(binned_array_3bins):
@@ -112,7 +113,6 @@ def test_colors(binned_array_3bins):
     f, ax = plt.subplots()
     im = ax.imshow(im_arr_bin, cmap="Blues")
     the_legend = ep.draw_legend(im_ax=im)
-    # NOTE: Do I know for sure things are rendering in the right order?
     legend_cols = [i.get_facecolor() for i in the_legend.get_patches()]
     # Get the array and cmap from axis object
     cmap_name = im.axes.get_images()[0].get_cmap().name
@@ -120,6 +120,7 @@ def test_colors(binned_array_3bins):
     image_colors = ep.make_col_list(unique_vals, cmap=cmap_name)
 
     assert image_colors == legend_cols
+    plt.close(f)
 
 
 def test_neg_vals(binned_array):

--- a/earthpy/tests/test_plot_rgb.py
+++ b/earthpy/tests/test_plot_rgb.py
@@ -63,6 +63,7 @@ def test_1band(rgb_image):
                            order with bands first""",
     ):
         plot_rgb(a_rgb_image[1])
+    plt.close()
 
 
 def test_ax_provided(rgb_image):
@@ -146,11 +147,11 @@ def test_stretch_output_scaled(rgb_image):
     """
     arr, _ = rgb_image
     stretch_vals = list(range(10))
-    axs = [plot_rgb(arr, stretch=True, str_clip=v)[1] for v in stretch_vals]
-    mean_vals = np.array([ax.get_images()[0].get_array().mean() for ax in axs])
-    n_unique_means = np.unique(mean_vals).shape[0]
-    assert n_unique_means == len(stretch_vals)
-    try:
-        axs
-    finally:
-        del axs
+
+    mean_vals = list()
+    for v in stretch_vals:
+        ax = plot_rgb(arr, stretch=True, str_clip=v)[1]
+        mean = ax.get_images()[0].get_array().mean()
+        mean_vals.append(mean)
+        plt.close()
+    assert len(set(mean_vals)) == len(stretch_vals)


### PR DESCRIPTION
This PR adds unit tests for the `EarthlabData` class. 

**Details**

- This also adds the pytest-vcr package as a dev requirement. To adequately test the `EarthlabData` class, we need to use the internet to see whether files exist, ensure files download, etc. The pytest-vcr package ensures that these downloads only happen once, using the @pytest.mark.vcr decorator for tests. More info can be found here: https://pytest-vcr.readthedocs.io/en/latest/ and some higher level conceptual background is here: https://vcrpy.readthedocs.io/en/latest/

- This PR cleans up unused and unnecessary imports in `earthpy/__init__.py`.

- The documentation for the `EarthlabData` class has been expanded as part of this PR. There are now examples of usage, and some attempts to warn users that the default behavior is to write to `~/earth-analytics/data/`.

- This also has some improvements to error messages and removes some copypasta in places. 

- The implementation of sorting out file names from arbitrary URLs has been fixed and streamlined. 

- An example of using `path_to_example` has been added. 

- The function `list_files` has been removed, as it is not used in earthpy or in any tutorials that I could find. The glob package in the standard library provides equivalent and better tested functionality. 