### PR TITLE
Clean up Plots in all tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Closing plots in tests (@lwasser #257)
 * Added a code of conduct (@mbjoseph, #27)
 
 ## [0.6.2] - 2019-02-19

--- a/earthpy/tests/test_plot.py
+++ b/earthpy/tests/test_plot.py
@@ -198,4 +198,4 @@ def test_hist_number_of_columns(image_array_2bands):
     for n in number_of_columns:
         f, ax = ep.hist(image_array_2bands, cols=n)
         assert [a.numCols for a in ax] == [n] * 2
-    plt.close()
+        plt.close(f)

--- a/earthpy/tests/test_plot.py
+++ b/earthpy/tests/test_plot.py
@@ -2,6 +2,9 @@
 
 import numpy as np
 import pytest
+import matplotlib as mpl
+
+mpl.use("TkAgg")
 import matplotlib.pyplot as plt
 import earthpy.plot as ep
 
@@ -15,6 +18,8 @@ def test_arr_parameter():
     """Raise an AttributeError if an array is not provided."""
     with pytest.raises(AttributeError):
         ep.plot_bands(arr=(1, 2))
+
+    plt.clf()
 
 
 def test_num_titles(image_array_2bands):
@@ -32,6 +37,7 @@ def test_num_titles(image_array_2bands):
         ep.plot_bands(
             arr=image_array_2bands, title=["Title1", "Title2", "Title3"]
         )
+    plt.clf()
 
 
 def test_num_axes(image_array_2bands):
@@ -41,6 +47,7 @@ def test_num_axes(image_array_2bands):
     """
     f, ax = ep.plot_bands(image_array_2bands)
     assert len(f.axes) == 3
+    plt.clf()
     plt.close(f)
 
 
@@ -52,6 +59,7 @@ def test_two_plot_title(image_array_2bands):
     num_plts = image_array_2bands.shape[0]
     all_titles = [ax[i].get_title() for i in range(num_plts)]
     assert all_titles == ["Band 1", "Band 2"]
+    plt.clf()
     plt.close(f)
 
 
@@ -62,6 +70,7 @@ def test_custom_plot_title(image_array_2bands):
     num_plts = image_array_2bands.shape[0]
     all_titles = [ax[i].get_title() for i in range(num_plts)]
     assert all_titles == ["Red Band", "Green Band"]
+    plt.clf()
     plt.close(f)
 
 
@@ -75,6 +84,7 @@ def test_single_band_3dims(one_band_3dims):
     arr = f.axes[0].get_images()[0].get_array()
     assert arr.ndim == 2
     assert len(f.axes[0].get_images()) == 1
+    plt.clf()
     plt.close(f)
 
 
@@ -90,6 +100,7 @@ def test_single_band_2dims(one_band_3dims):
     arr = f.axes[0].get_images()[0].get_array()
     assert arr.ndim == 2
     assert len(f.axes[0].get_images()) == 1
+    plt.clf()
     plt.close(f)
 
 
@@ -102,6 +113,7 @@ def test_colorbar_height(basic_image):
     im = ax.imshow(basic_image, cmap="RdYlGn")
     cb = ep.colorbar(im)
     assert cb.ax.get_position().height == im.axes.get_position().height
+    plt.clf()
     plt.close(f)
 
 
@@ -109,6 +121,7 @@ def test_colorbar_raises_value_error():
     """Test that a non matbplotlib axis object raises an value error."""
     with pytest.raises(AttributeError, match="requires a matplotlib"):
         ep.colorbar(list())
+    plt.clf()
 
 
 """ Hist tests """
@@ -126,6 +139,7 @@ def test_num_axes_hist(image_array_2bands, basic_image):
     assert len(f_1.axes) == 1
     f_2, ax_2 = ep.hist(image_array_2bands)
     assert len(f_2.axes) == 2
+    plt.clf()
 
 
 def test_single_hist_title(basic_image):
@@ -133,6 +147,7 @@ def test_single_hist_title(basic_image):
     custom_title = "Great hist"
     f, ax = ep.hist(basic_image, title=[custom_title])
     assert ax.get_title() == custom_title
+    plt.clf()
 
 
 def test_multiband_hist_title(image_array_2bands):
@@ -141,6 +156,7 @@ def test_multiband_hist_title(image_array_2bands):
     f, ax = ep.hist(image_array_2bands, title=custom_titles)
     num_plts = image_array_2bands.shape[0]
     assert [f.axes[i].get_title() for i in range(num_plts)] == custom_titles
+    plt.clf()
 
 
 def test_number_of_hist_bins(basic_image):
@@ -149,6 +165,7 @@ def test_number_of_hist_bins(basic_image):
     for n in n_bins:
         f, ax = ep.hist(basic_image, bins=n)
         assert n == len(ax.patches)
+    plt.clf()
 
 
 def test_hist_bbox(basic_image):
@@ -156,6 +173,7 @@ def test_hist_bbox(basic_image):
     f, ax = ep.hist(basic_image, figsize=(50, 3))
     bbox = str(f.__dict__.get("bbox_inches"))
     assert bbox == "Bbox(x0=0.0, y0=0.0, x1=50.0, y1=3.0)"
+    plt.clf()
 
 
 def test_hist_color_single_band(basic_image):
@@ -163,6 +181,8 @@ def test_hist_color_single_band(basic_image):
     f, ax = ep.hist(basic_image, colors=["red"])
     facecolor = ax.patches[0].__dict__.get("_original_facecolor")
     assert np.array_equal(facecolor, np.array([1.0, 0.0, 0.0, 1.0]))
+    plt.clf()
+    plt.close(f)
 
 
 def test_hist_color_multi_band(image_array_2bands):
@@ -175,6 +195,8 @@ def test_hist_color_multi_band(image_array_2bands):
     ]
     for i in range(2):
         assert np.array_equal(colors[i], expected_colors[i])
+    plt.clf()
+    plt.close(f)
 
 
 def test_hist_number_of_columns(image_array_2bands):
@@ -183,3 +205,8 @@ def test_hist_number_of_columns(image_array_2bands):
     for n in number_of_columns:
         f, ax = ep.hist(image_array_2bands, cols=n)
         assert [a.numCols for a in ax] == [n] * 2
+    plt.clf()
+    plt.close()
+
+
+plt.close("all")

--- a/earthpy/tests/test_plot.py
+++ b/earthpy/tests/test_plot.py
@@ -18,8 +18,7 @@ def test_arr_parameter():
     """Raise an AttributeError if an array is not provided."""
     with pytest.raises(AttributeError):
         ep.plot_bands(arr=(1, 2))
-
-    plt.clf()
+    plt.close()
 
 
 def test_num_titles(image_array_2bands):
@@ -37,7 +36,7 @@ def test_num_titles(image_array_2bands):
         ep.plot_bands(
             arr=image_array_2bands, title=["Title1", "Title2", "Title3"]
         )
-    plt.clf()
+    plt.close()
 
 
 def test_num_axes(image_array_2bands):
@@ -47,7 +46,6 @@ def test_num_axes(image_array_2bands):
     """
     f, ax = ep.plot_bands(image_array_2bands)
     assert len(f.axes) == 3
-    plt.clf()
     plt.close(f)
 
 
@@ -59,7 +57,6 @@ def test_two_plot_title(image_array_2bands):
     num_plts = image_array_2bands.shape[0]
     all_titles = [ax[i].get_title() for i in range(num_plts)]
     assert all_titles == ["Band 1", "Band 2"]
-    plt.clf()
     plt.close(f)
 
 
@@ -70,7 +67,6 @@ def test_custom_plot_title(image_array_2bands):
     num_plts = image_array_2bands.shape[0]
     all_titles = [ax[i].get_title() for i in range(num_plts)]
     assert all_titles == ["Red Band", "Green Band"]
-    plt.clf()
     plt.close(f)
 
 
@@ -84,7 +80,6 @@ def test_single_band_3dims(one_band_3dims):
     arr = f.axes[0].get_images()[0].get_array()
     assert arr.ndim == 2
     assert len(f.axes[0].get_images()) == 1
-    plt.clf()
     plt.close(f)
 
 
@@ -100,7 +95,6 @@ def test_single_band_2dims(one_band_3dims):
     arr = f.axes[0].get_images()[0].get_array()
     assert arr.ndim == 2
     assert len(f.axes[0].get_images()) == 1
-    plt.clf()
     plt.close(f)
 
 
@@ -113,7 +107,6 @@ def test_colorbar_height(basic_image):
     im = ax.imshow(basic_image, cmap="RdYlGn")
     cb = ep.colorbar(im)
     assert cb.ax.get_position().height == im.axes.get_position().height
-    plt.clf()
     plt.close(f)
 
 
@@ -121,7 +114,7 @@ def test_colorbar_raises_value_error():
     """Test that a non matbplotlib axis object raises an value error."""
     with pytest.raises(AttributeError, match="requires a matplotlib"):
         ep.colorbar(list())
-    plt.clf()
+    plt.close()
 
 
 """ Hist tests """
@@ -131,6 +124,7 @@ def test_num_plot_titles_mismatch_hist(image_array_2bands):
     """Raise an error if the number of titles != number of bands."""
     with pytest.raises(ValueError, match="number of plot titles"):
         ep.hist(image_array_2bands, title=["One", "too", "many"])
+    plt.close()
 
 
 def test_num_axes_hist(image_array_2bands, basic_image):
@@ -139,7 +133,8 @@ def test_num_axes_hist(image_array_2bands, basic_image):
     assert len(f_1.axes) == 1
     f_2, ax_2 = ep.hist(image_array_2bands)
     assert len(f_2.axes) == 2
-    plt.clf()
+    plt.close(f_1)
+    plt.close(f_2)
 
 
 def test_single_hist_title(basic_image):
@@ -147,7 +142,7 @@ def test_single_hist_title(basic_image):
     custom_title = "Great hist"
     f, ax = ep.hist(basic_image, title=[custom_title])
     assert ax.get_title() == custom_title
-    plt.clf()
+    plt.close(f)
 
 
 def test_multiband_hist_title(image_array_2bands):
@@ -156,7 +151,7 @@ def test_multiband_hist_title(image_array_2bands):
     f, ax = ep.hist(image_array_2bands, title=custom_titles)
     num_plts = image_array_2bands.shape[0]
     assert [f.axes[i].get_title() for i in range(num_plts)] == custom_titles
-    plt.clf()
+    plt.close(f)
 
 
 def test_number_of_hist_bins(basic_image):
@@ -165,7 +160,7 @@ def test_number_of_hist_bins(basic_image):
     for n in n_bins:
         f, ax = ep.hist(basic_image, bins=n)
         assert n == len(ax.patches)
-    plt.clf()
+        plt.close()
 
 
 def test_hist_bbox(basic_image):
@@ -173,7 +168,7 @@ def test_hist_bbox(basic_image):
     f, ax = ep.hist(basic_image, figsize=(50, 3))
     bbox = str(f.__dict__.get("bbox_inches"))
     assert bbox == "Bbox(x0=0.0, y0=0.0, x1=50.0, y1=3.0)"
-    plt.clf()
+    plt.close()
 
 
 def test_hist_color_single_band(basic_image):
@@ -181,7 +176,6 @@ def test_hist_color_single_band(basic_image):
     f, ax = ep.hist(basic_image, colors=["red"])
     facecolor = ax.patches[0].__dict__.get("_original_facecolor")
     assert np.array_equal(facecolor, np.array([1.0, 0.0, 0.0, 1.0]))
-    plt.clf()
     plt.close(f)
 
 
@@ -195,7 +189,6 @@ def test_hist_color_multi_band(image_array_2bands):
     ]
     for i in range(2):
         assert np.array_equal(colors[i], expected_colors[i])
-    plt.clf()
     plt.close(f)
 
 
@@ -205,8 +198,4 @@ def test_hist_number_of_columns(image_array_2bands):
     for n in number_of_columns:
         f, ax = ep.hist(image_array_2bands, cols=n)
         assert [a.numCols for a in ax] == [n] * 2
-    plt.clf()
     plt.close()
-
-
-plt.close("all")

--- a/earthpy/tests/test_plot_draw_legend.py
+++ b/earthpy/tests/test_plot_draw_legend.py
@@ -46,7 +46,7 @@ def test_num_titles_classes(binned_array_3bins):
     bins, im_arr_bin = binned_array_3bins
     im_arr_bin[im_arr_bin == 2] = 3
 
-    fig, ax = plt.subplots(figsize=(5, 5))
+    f, ax = plt.subplots(figsize=(5, 5))
     im_ax = ax.imshow(im_arr_bin, cmap="Blues")
 
     with pytest.raises(ValueError):
@@ -58,6 +58,8 @@ def test_num_titles_classes(binned_array_3bins):
         ep.draw_legend(
             im_ax=im_ax, classes=[1, 2, 3], titles=["small", "large"]
         )
+    plt.clf()
+    plt.close(f)
 
 
 def test_stock_legend_titles(binned_array_3bins):
@@ -76,6 +78,7 @@ def test_stock_legend_titles(binned_array_3bins):
     # Legend handle titles should equal unique values in ax array
     assert len(the_legend.get_texts()) == len(np.unique(imp2.get_array().data))
     assert def_titles == [text.get_text() for text in the_legend.get_texts()]
+    plt.clf()
     plt.close(f)
 
 
@@ -93,6 +96,7 @@ def test_custom_legend_titles(binned_array_3bins):
     assert custom_titles == [
         text.get_text() for text in the_legend.get_texts()
     ]
+    plt.clf()
     plt.close(f)
 
 
@@ -102,6 +106,8 @@ def test_non_ax_obj():
 
     with pytest.raises(AttributeError):
         ep.draw_legend(im_ax=list())
+    plt.clf()
+    plt.close()
 
 
 def test_colors(binned_array_3bins):
@@ -120,6 +126,8 @@ def test_colors(binned_array_3bins):
     image_colors = ep.make_col_list(unique_vals, cmap=cmap_name)
 
     assert image_colors == legend_cols
+    plt.clf()
+    plt.close(f)
 
 
 def test_neg_vals(binned_array):
@@ -132,6 +140,7 @@ def test_neg_vals(binned_array):
     leg_neg = ep.draw_legend(im_ax)
     legend_cols = [i.get_facecolor() for i in leg_neg.get_patches()]
     assert len(legend_cols) == len(bins) - 1
+    plt.clf()
     plt.close(f)
 
 
@@ -150,6 +159,7 @@ def test_listed_cmap(binned_array):
     leg = ep.draw_legend(im_plt)
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len(bins) - 1
+    plt.clf()
     plt.close(f)
 
 
@@ -170,6 +180,7 @@ def test_noncont_listed_cmap(binned_array, listed_cmap):
 
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len(np.unique(arr_class))
+    plt.clf()
     plt.close(f)
 
 
@@ -187,6 +198,7 @@ def test_noncont_listed_cmap_3_classes(binned_array, listed_cmap):
 
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len([1, 2, 3, 4, 5])
+    plt.clf()
     plt.close(f)
 
 
@@ -205,6 +217,7 @@ def test_masked_vals():
     leg = ep.draw_legend(im_ax)
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len(unmasked_vals)
+    plt.clf()
     plt.close(f)
 
 
@@ -219,4 +232,8 @@ def test_subplots(binned_array):
 
     im_ax2 = ax2.imshow(arr_class)
     ep.draw_legend(im_ax2)
+    plt.clf()
     plt.close(f)
+
+
+plt.close("all")

--- a/earthpy/tests/test_plot_draw_legend.py
+++ b/earthpy/tests/test_plot_draw_legend.py
@@ -58,7 +58,6 @@ def test_num_titles_classes(binned_array_3bins):
         ep.draw_legend(
             im_ax=im_ax, classes=[1, 2, 3], titles=["small", "large"]
         )
-    plt.clf()
     plt.close(f)
 
 
@@ -78,7 +77,6 @@ def test_stock_legend_titles(binned_array_3bins):
     # Legend handle titles should equal unique values in ax array
     assert len(the_legend.get_texts()) == len(np.unique(imp2.get_array().data))
     assert def_titles == [text.get_text() for text in the_legend.get_texts()]
-    plt.clf()
     plt.close(f)
 
 
@@ -96,7 +94,6 @@ def test_custom_legend_titles(binned_array_3bins):
     assert custom_titles == [
         text.get_text() for text in the_legend.get_texts()
     ]
-    plt.clf()
     plt.close(f)
 
 
@@ -106,8 +103,6 @@ def test_non_ax_obj():
 
     with pytest.raises(AttributeError):
         ep.draw_legend(im_ax=list())
-    plt.clf()
-    plt.close()
 
 
 def test_colors(binned_array_3bins):
@@ -118,7 +113,6 @@ def test_colors(binned_array_3bins):
     f, ax = plt.subplots()
     im = ax.imshow(im_arr_bin, cmap="Blues")
     the_legend = ep.draw_legend(im_ax=im)
-    # NOTE: Do I know for sure things are rendering in the right order?
     legend_cols = [i.get_facecolor() for i in the_legend.get_patches()]
     # Get the array and cmap from axis object
     cmap_name = im.axes.get_images()[0].get_cmap().name
@@ -126,7 +120,6 @@ def test_colors(binned_array_3bins):
     image_colors = ep.make_col_list(unique_vals, cmap=cmap_name)
 
     assert image_colors == legend_cols
-    plt.clf()
     plt.close(f)
 
 
@@ -140,7 +133,6 @@ def test_neg_vals(binned_array):
     leg_neg = ep.draw_legend(im_ax)
     legend_cols = [i.get_facecolor() for i in leg_neg.get_patches()]
     assert len(legend_cols) == len(bins) - 1
-    plt.clf()
     plt.close(f)
 
 
@@ -159,7 +151,6 @@ def test_listed_cmap(binned_array):
     leg = ep.draw_legend(im_plt)
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len(bins) - 1
-    plt.clf()
     plt.close(f)
 
 
@@ -180,7 +171,6 @@ def test_noncont_listed_cmap(binned_array, listed_cmap):
 
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len(np.unique(arr_class))
-    plt.clf()
     plt.close(f)
 
 
@@ -198,7 +188,6 @@ def test_noncont_listed_cmap_3_classes(binned_array, listed_cmap):
 
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len([1, 2, 3, 4, 5])
-    plt.clf()
     plt.close(f)
 
 
@@ -217,7 +206,6 @@ def test_masked_vals():
     leg = ep.draw_legend(im_ax)
     legend_cols = [i.get_facecolor() for i in leg.get_patches()]
     assert len(legend_cols) == len(unmasked_vals)
-    plt.clf()
     plt.close(f)
 
 
@@ -232,8 +220,4 @@ def test_subplots(binned_array):
 
     im_ax2 = ax2.imshow(arr_class)
     ep.draw_legend(im_ax2)
-    plt.clf()
     plt.close(f)
-
-
-plt.close("all")

--- a/earthpy/tests/test_plot_rgb.py
+++ b/earthpy/tests/test_plot_rgb.py
@@ -147,13 +147,15 @@ def test_stretch_output_scaled(rgb_image):
     """
     arr, _ = rgb_image
     stretch_vals = list(range(10))
-    axs = [plot_rgb(arr, stretch=True, str_clip=v)[1] for v in stretch_vals]
-    mean_vals = np.array([ax.get_images()[0].get_array().mean() for ax in axs])
-    n_unique_means = np.unique(mean_vals).shape[0]
-    assert n_unique_means == len(stretch_vals)
-    try:
-        axs
-    finally:
-        del axs
 
-    plt.close()
+    mean_vals = list()
+    for v in stretch_vals:
+        ax = plot_rgb(arr, stretch=True, str_clip=v)[1]
+        mean = ax.get_images()[0].get_array().mean()
+        mean_vals.append(mean)
+        plt.close()
+    assert len(set(mean_vals)) == len(stretch_vals)
+    try:
+        ax
+    finally:
+        del ax

--- a/earthpy/tests/test_plot_rgb.py
+++ b/earthpy/tests/test_plot_rgb.py
@@ -155,7 +155,3 @@ def test_stretch_output_scaled(rgb_image):
         mean_vals.append(mean)
         plt.close()
     assert len(set(mean_vals)) == len(stretch_vals)
-    try:
-        ax
-    finally:
-        del ax

--- a/earthpy/tests/test_plot_rgb.py
+++ b/earthpy/tests/test_plot_rgb.py
@@ -49,6 +49,7 @@ def test_rgb_extent(rgb_image):
     assert ax.get_title() == "My Title"
     assert np.array_equal(plt_array[0], a_rgb_image.transpose([1, 2, 0])[1])
     assert ext == plt_ext
+    plt.clf()
     plt.close(f)
 
 
@@ -63,6 +64,8 @@ def test_1band(rgb_image):
                            order with bands first""",
     ):
         plot_rgb(a_rgb_image[1])
+    plt.clf()
+    plt.close()
 
 
 def test_ax_provided(rgb_image):
@@ -74,6 +77,7 @@ def test_ax_provided(rgb_image):
     rgb_im_shape = rgb_image.transpose([1, 2, 0]).shape
     the_plot_im_shape = ax.get_images()[0].get_array().shape
     assert rgb_im_shape == the_plot_im_shape
+    plt.clf()
     plt.close(f)
 
 
@@ -86,6 +90,7 @@ def test_ax_not_provided(rgb_image):
     rgb_im_shape = rgb_image.transpose([1, 2, 0]).shape
     the_plot_im_shape = ax.get_images()[0].get_array().shape
     assert rgb_im_shape == the_plot_im_shape
+    plt.clf()
     plt.close(f)
 
 
@@ -99,6 +104,7 @@ def test_stretch_image(rgb_image):
     f, ax = plot_rgb(im, stretch=True)
     max_val = ax.get_images()[0].get_array().max()
     assert max_val == 255
+    plt.clf()
     plt.close(f)
 
 
@@ -113,6 +119,7 @@ def test_masked_im(rgb_image):
     f, ax = plot_rgb(im_ma)
     im_plot = ax.get_images()[0].get_array()
     assert im_plot.shape[2] == 4
+    plt.clf()
     plt.close(f)
 
 
@@ -125,6 +132,7 @@ def test_ticks_off(rgb_image):
     f, ax = plot_rgb(im)
     assert len(ax.get_xticks()) == 0
     assert len(ax.get_yticks()) == 0
+    plt.clf()
     plt.close(f)
 
 
@@ -154,3 +162,6 @@ def test_stretch_output_scaled(rgb_image):
         axs
     finally:
         del axs
+
+
+plt.close("all")

--- a/earthpy/tests/test_plot_rgb.py
+++ b/earthpy/tests/test_plot_rgb.py
@@ -49,7 +49,6 @@ def test_rgb_extent(rgb_image):
     assert ax.get_title() == "My Title"
     assert np.array_equal(plt_array[0], a_rgb_image.transpose([1, 2, 0])[1])
     assert ext == plt_ext
-    plt.clf()
     plt.close(f)
 
 
@@ -64,7 +63,6 @@ def test_1band(rgb_image):
                            order with bands first""",
     ):
         plot_rgb(a_rgb_image[1])
-    plt.clf()
     plt.close()
 
 
@@ -77,7 +75,6 @@ def test_ax_provided(rgb_image):
     rgb_im_shape = rgb_image.transpose([1, 2, 0]).shape
     the_plot_im_shape = ax.get_images()[0].get_array().shape
     assert rgb_im_shape == the_plot_im_shape
-    plt.clf()
     plt.close(f)
 
 
@@ -90,7 +87,6 @@ def test_ax_not_provided(rgb_image):
     rgb_im_shape = rgb_image.transpose([1, 2, 0]).shape
     the_plot_im_shape = ax.get_images()[0].get_array().shape
     assert rgb_im_shape == the_plot_im_shape
-    plt.clf()
     plt.close(f)
 
 
@@ -104,7 +100,6 @@ def test_stretch_image(rgb_image):
     f, ax = plot_rgb(im, stretch=True)
     max_val = ax.get_images()[0].get_array().max()
     assert max_val == 255
-    plt.clf()
     plt.close(f)
 
 
@@ -119,7 +114,6 @@ def test_masked_im(rgb_image):
     f, ax = plot_rgb(im_ma)
     im_plot = ax.get_images()[0].get_array()
     assert im_plot.shape[2] == 4
-    plt.clf()
     plt.close(f)
 
 
@@ -132,7 +126,6 @@ def test_ticks_off(rgb_image):
     f, ax = plot_rgb(im)
     assert len(ax.get_xticks()) == 0
     assert len(ax.get_yticks()) == 0
-    plt.clf()
     plt.close(f)
 
 
@@ -163,5 +156,4 @@ def test_stretch_output_scaled(rgb_image):
     finally:
         del axs
 
-
-plt.close("all")
+    plt.close()


### PR DESCRIPTION
This PR should address the warning associated with open figures in matplotlib. Essentially `.close` closes any open windows and `.clf` clears the actual figure.

```
earthpy/tests/test_plot_rgb.py::test_stretch_output_scaled
  /Users/leahwasser/anaconda3/envs/earthpy-dev/lib/python3.6/site-packages/matplotlib/pyplot.py:514: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).
    max_open_warning, RuntimeWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

```