### PR TITLE
Remove dependency on download library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Remove dependency on download library (@mbjoseph #249)
 * Remove earthpy.utils.fix_paths as it is not used in the package (@lwasser #259)
 * Adding tests for hillshade and improved docs (@jpalomino #260)
 * Closing plots in tests (@lwasser #257)
-* Added a code of conduct (@mbjoseph, #27)
-* Added tests for EarthlabData class (@mbjoseph, #37)
+* Added a code of conduct (@mbjoseph #27)
+* Added tests for EarthlabData class (@mbjoseph #37)
 
 ## [0.6.2] - 2019-02-19
 We have made significant changes in preparation for a 1.0 release

--- a/docs/earthpy.rst
+++ b/docs/earthpy.rst
@@ -44,14 +44,6 @@ earthpy.spatial module
     :undoc-members:
     :show-inheritance:
 
-earthpy.utils module
---------------------
-
-.. automodule:: earthpy.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 
 Module contents
 ---------------

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
 
   - pip:
       # Utilities
-      - download
       - mne
       - sklearn
       - tqdm

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ if __name__ == "__main__":
             "geopandas",
             "matplotlib>=2.0.0",
             "rasterio",
-            "download",
             "scikit-image",
         ],
         zip_safe=False,  # the package can run out of an .egg file


### PR DESCRIPTION
This reimplements data downloads for the `earthpy.io.Data` class, removing the dependency on the download library. This will help with #249.

There's one minor change to the behavior of `earthpy.io.Data` with this PR: instead of automatically extracting `.tar` and `.tar.gz` files, this will just download them. @lwasser if this is a problem for any of the lessons, let me know! I couldn't find any instances where there were tar files being used. With this implementation, users would download the files, then untar them afterwards. 