### PR TITLE
fixing bug in mask

### DIFF
--- a/earthpy/mask.py
+++ b/earthpy/mask.py
@@ -110,14 +110,17 @@ def _create_mask(mask_arr, vals):
     except AttributeError:
         raise AttributeError("Values should be provided as a list")
 
-    unique_vals = np.unique(mask_arr).tolist()
+    # For some reason if you don't copy this here, it magically changes the input
+    # qa layer to a boolean in the main environment.
+    new_mask_arr = mask_arr.copy()
+    unique_vals = np.unique(new_mask_arr).tolist()
 
     if any(num in vals for num in unique_vals):
-        temp_mask = np.isin(mask_arr, vals)
-        mask_arr[temp_mask] = 1
-        mask_arr[~temp_mask] = 0
+        temp_mask = np.isin(new_mask_arr, vals)
+        new_mask_arr[temp_mask] = 1
+        new_mask_arr[~temp_mask] = 0
 
-        return mask_arr
+        return new_mask_arr
 
     else:
         raise ValueError(


### PR DESCRIPTION
This addresses [this issue](https://github.com/earthlab/earthpy/issues/276)

This  issue is bizarre as you wouldn't not expect a parameter input to be MODIFIED via an earthpy function but in this case, the input QA layer is actually modified in the function into a boolean.

To avoid this behavior, i've created a copy of the input parameter so the user doesn't get any surprises.