### PR TITLE
Test earthpy on OS X with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,31 @@
-dist: xenial
-
 language: python
 
-python:
-- "3.5"
-- "3.6"
-- "3.7"
+# python versions for osx builds are taken as the most recent from:
+# https://www.python.org/downloads/
+matrix:
+    include:
+        - os: linux
+          dist: xenial
+          python: 3.5
+          env: TOXENV=py35
+        - os: linux
+          dist: xenial
+          python: 3.6
+          env: TOXENV=py36
+        - os: linux
+          dist: xenial
+          python: 3.7
+          env: TOXENV=py37,black,docs
+        - os: osx
+          language: generic
 
-before_install:
-  - sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable --yes
-  - sudo apt-get update
-  - sudo apt-get install -y libspatialindex-dev libgdal-dev python3-tk
+install:
+  - chmod +x .travis/install.sh
+  - ./.travis/install.sh
 
-install: pip install -U tox-travis
-
-script: tox
+script:
+  - chmod +x .travis/test.sh
+  - ./.travis/test.sh
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-# python versions for osx builds are taken as the most recent from:
-# https://www.python.org/downloads/
 matrix:
     include:
         - os: linux

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+
+  # install conda and the earthpy-dev environment
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
+  bash ~/miniconda.sh -b -p $HOME/miniconda
+  export PATH="$HOME/miniconda/bin:$PATH"
+  echo "conda activate base" >> ~/.bashrc
+  source $HOME/miniconda/bin/activate
+  conda config --set always_yes yes --set show_channel_urls true --set changeps1 no
+  conda update -q conda
+  conda config --add channels conda-forge
+  conda info -a
+  conda init bash
+  conda env create -f environment.yml
+  conda activate earthpy-dev
+  python setup.py install
+  pip install -r dev-requirements.txt
+
+else
+  sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable --yes
+  sudo apt-get update
+  sudo apt-get install -y libspatialindex-dev libgdal-dev python3-tk
+  pip install tox-travis
+fi

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+  source $HOME/miniconda/bin/activate
+  export PATH="$HOME/miniconda/bin:$PATH"
+  conda activate earthpy-dev
+  python -m pytest -v
+  make -B docs
+else
+  tox
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add continuous integration testing on osx via Travis CI (@mbjoseph #228)
 * Add cbar legend to `plot_bands()` and scaling parameters (@lwasser #274)
 * BUGFIX: `plot_bands()` doesn't plot single string titles properly + add test (@lwasser #258)
 * Remove dependency on download library (@mbjoseph #249)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -r{toxinidir}/dev-requirements.txt
 whitelist_externals = pytest
 commands =
-    pytest --basetemp={envtmpdir} --cov=earthpy
+    pytest -v --basetemp={envtmpdir} --cov=earthpy
     codecov -e TOXENV
 
 [testenv:black]


### PR DESCRIPTION
This PR adds support for OS X testing in our Travis build. This uses conda to set up the dependencies, which is probably going to be the most common use case for mac users. 

With this PR, we will have testing on linux, OS X, and Windows. Closes #228.