### PR TITLE
Use a MANIFEST.in file to distribute the LICENSE and README

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -54,4 +54,5 @@ if __name__ == "__main__":
                 "example-data/*.dbf",
             ]
         },
+        url="https://github.com/earthlab/earthpy",
     )


### PR DESCRIPTION
Solves #298, and will help us get EarthPy on conda-forge. 

@lwasser if this looks good to you, please merge! 

We will also need to deploy a patch to PyPI after merging this to ensure that the conda-forge build has access to the LICENSE file, which it needs for the earthpy recipe. 

This PR also specifies a url in `setup.py` to make it easier for people to find the repo's webpage from the source code. 