### PR TITLE
Test Cleanup & Re-org

### DIFF
--- a/earthpy/tests/conftest.py
+++ b/earthpy/tests/conftest.py
@@ -5,7 +5,6 @@ from affine import Affine
 import rasterio as rio
 
 
-# used several times
 @pytest.fixture
 def basic_image():
     """
@@ -22,7 +21,6 @@ def basic_image():
     return image
 
 
-# used several times
 @pytest.fixture
 def basic_image_tif(tmpdir, basic_image):
     """
@@ -49,7 +47,6 @@ def basic_image_tif(tmpdir, basic_image):
     return outfilename
 
 
-# used several times
 @pytest.fixture
 def image_array_2bands():
     return np.random.randint(10, size=(2, 4, 5))

--- a/earthpy/tests/conftest.py
+++ b/earthpy/tests/conftest.py
@@ -1,128 +1,11 @@
 """ Utility functions for tests. """
 import numpy as np
 import pytest
-from shapely.geometry import Polygon, Point, LineString
 from affine import Affine
 import rasterio as rio
-import geopandas as gpd
 
 
-def make_locs_gdf():
-    """ Create a dummy point GeoDataFrame. """
-    pts = np.array([[2, 2], [3, 4], [9, 8], [-12, -15]])
-    gdf = gpd.GeoDataFrame(
-        [Point(xy) for xy in pts],
-        columns=["geometry"],
-        crs={"init": "epsg:4326"},
-    )
-    return gdf
-
-
-def make_poly_in_gdf():
-    """ Bounding box polygon. """
-    poly_inters = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
-    gdf = gpd.GeoDataFrame(
-        [1], geometry=[poly_inters], crs={"init": "epsg:4326"}
-    )
-    return gdf
-
-
-def make_locs_buff():
-    """ Buffer points to create multi poly. """
-    buffered_locations = make_locs_gdf()
-    buffered_locations["geometry"] = buffered_locations.buffer(4)
-    return buffered_locations
-
-
-def make_donut_geom():
-    """ Make a donut geometry. """
-    donut = gpd.overlay(
-        make_locs_buff(), make_poly_in_gdf(), how="symmetric_difference"
-    )
-    return donut
-
-
-@pytest.fixture
-def locs_gdf():
-    """ Get a dummy point GeoDataFrame.
-
-    This fixture calls make_locs_gdf(), which is a function that is used in
-    multiple fixtures. But, fixtures are not supposed to be used like that:
-
-    see https://github.com/pytest-dev/pytest/issues/3950 for discussion
-    """
-    return make_locs_gdf()
-
-
-@pytest.fixture
-def linez_gdf():
-    """ Create Line Objects For Testing """
-    linea = LineString([(1, 1), (2, 2), (3, 2), (5, 3)])
-    lineb = LineString([(3, 4), (5, 7), (12, 2), (10, 5), (9, 7.5)])
-    gdf = gpd.GeoDataFrame(
-        [1, 2], geometry=[linea, lineb], crs={"init": "epsg:4326"}
-    )
-    return gdf
-
-
-@pytest.fixture
-def poly_in_gdf():
-    """ Fixture for a bounding box polygon. """
-    return make_poly_in_gdf()
-
-
-@pytest.fixture
-def locs_buff():
-    """ Fixture for buffered locations. """
-    return make_locs_buff()
-
-
-@pytest.fixture
-def donut_geom():
-    """ Fixture for donut geometry objects. """
-    return make_donut_geom()
-
-
-@pytest.fixture
-def multi_gdf():
-    """ Create a multi-polygon GeoDataFrame. """
-    multi_poly = make_donut_geom().unary_union
-    out_df = gpd.GeoDataFrame(
-        gpd.GeoSeries(multi_poly), crs={"init": "epsg:4326"}
-    )
-    out_df = out_df.rename(columns={0: "geometry"}).set_geometry("geometry")
-    return out_df
-
-
-@pytest.fixture
-def basic_geometry():
-    """
-    A square polygon spanning (2, 2) to (4.25, 4.25) in x and y directions
-    Borrowed from rasterio/tests/conftest.py
-
-    Returns
-    -------
-    dict: GeoJSON-style geometry object.
-        Coordinates are in grid coordinates (Affine.identity()).
-    """
-    return Polygon([(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)])
-
-
-@pytest.fixture
-def basic_geometry_gdf(basic_geometry):
-    """
-    A GeoDataFrame containing the basic geometry
-
-    Returns
-    -------
-    GeoDataFrame containing the basic_geometry polygon
-    """
-    gdf = gpd.GeoDataFrame(
-        geometry=[basic_geometry], crs={"init": "epsg:4326"}
-    )
-    return gdf
-
-
+# used several times
 @pytest.fixture
 def basic_image():
     """
@@ -139,6 +22,7 @@ def basic_image():
     return image
 
 
+# used several times
 @pytest.fixture
 def basic_image_tif(tmpdir, basic_image):
     """
@@ -165,15 +49,7 @@ def basic_image_tif(tmpdir, basic_image):
     return outfilename
 
 
+# used several times
 @pytest.fixture
 def image_array_2bands():
     return np.random.randint(10, size=(2, 4, 5))
-
-
-@pytest.fixture
-def one_band_3dims():
-    """Return a 3-dim numpy array vals 0-9"""
-
-    return np.array(
-        [[[8, 0, 2, 6, 3], [2, 8, 2, 8, 4], [3, 9, 1, 5, 4], [5, 9, 2, 7, 7]]]
-    )

--- a/earthpy/tests/test_clip.py
+++ b/earthpy/tests/test_clip.py
@@ -1,10 +1,104 @@
 """Tests for the clip module."""
 
 import pytest
-from shapely.geometry import Polygon
+import numpy as np
+from shapely.geometry import Polygon, Point, LineString
 import shapely
 import geopandas as gpd
 import earthpy.clip as cl
+
+
+def make_locs_gdf():
+    """ Create a dummy point GeoDataFrame. """
+    pts = np.array([[2, 2], [3, 4], [9, 8], [-12, -15]])
+    gdf = gpd.GeoDataFrame(
+        [Point(xy) for xy in pts],
+        columns=["geometry"],
+        crs={"init": "epsg:4326"},
+    )
+    return gdf
+
+
+def make_poly_in_gdf():
+    """ Bounding box polygon. """
+    poly_inters = Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)])
+    gdf = gpd.GeoDataFrame(
+        [1], geometry=[poly_inters], crs={"init": "epsg:4326"}
+    )
+    return gdf
+
+
+def make_locs_buff():
+    """ Buffer points to create multi poly. """
+    buffered_locations = make_locs_gdf()
+    buffered_locations["geometry"] = buffered_locations.buffer(4)
+    return buffered_locations
+
+
+def make_donut_geom():
+    """ Make a donut geometry. """
+    donut = gpd.overlay(
+        make_locs_buff(), make_poly_in_gdf(), how="symmetric_difference"
+    )
+    return donut
+
+
+# test_clip
+@pytest.fixture
+def locs_gdf():
+    """ Get a dummy point GeoDataFrame.
+
+    This fixture calls make_locs_gdf(), which is a function that is used in
+    multiple fixtures. But, fixtures are not supposed to be used like that:
+
+    see https://github.com/pytest-dev/pytest/issues/3950 for discussion
+    """
+    return make_locs_gdf()
+
+
+# test_clip
+@pytest.fixture
+def linez_gdf():
+    """ Create Line Objects For Testing """
+    linea = LineString([(1, 1), (2, 2), (3, 2), (5, 3)])
+    lineb = LineString([(3, 4), (5, 7), (12, 2), (10, 5), (9, 7.5)])
+    gdf = gpd.GeoDataFrame(
+        [1, 2], geometry=[linea, lineb], crs={"init": "epsg:4326"}
+    )
+    return gdf
+
+
+# test_clip
+@pytest.fixture
+def poly_in_gdf():
+    """ Fixture for a bounding box polygon. """
+    return make_poly_in_gdf()
+
+
+# test_clip
+@pytest.fixture
+def locs_buff():
+    """ Fixture for buffered locations. """
+    return make_locs_buff()
+
+
+# test_clip
+@pytest.fixture
+def donut_geom():
+    """ Fixture for donut geometry objects. """
+    return make_donut_geom()
+
+
+# test_clip
+@pytest.fixture
+def multi_gdf():
+    """ Create a multi-polygon GeoDataFrame. """
+    multi_poly = make_donut_geom().unary_union
+    out_df = gpd.GeoDataFrame(
+        gpd.GeoSeries(multi_poly), crs={"init": "epsg:4326"}
+    )
+    out_df = out_df.rename(columns={0: "geometry"}).set_geometry("geometry")
+    return out_df
 
 
 def test_not_gdf(poly_in_gdf):

--- a/earthpy/tests/test_clip.py
+++ b/earthpy/tests/test_clip.py
@@ -43,7 +43,6 @@ def make_donut_geom():
     return donut
 
 
-# test_clip
 @pytest.fixture
 def locs_gdf():
     """ Get a dummy point GeoDataFrame.
@@ -56,7 +55,6 @@ def locs_gdf():
     return make_locs_gdf()
 
 
-# test_clip
 @pytest.fixture
 def linez_gdf():
     """ Create Line Objects For Testing """
@@ -68,28 +66,24 @@ def linez_gdf():
     return gdf
 
 
-# test_clip
 @pytest.fixture
 def poly_in_gdf():
     """ Fixture for a bounding box polygon. """
     return make_poly_in_gdf()
 
 
-# test_clip
 @pytest.fixture
 def locs_buff():
     """ Fixture for buffered locations. """
     return make_locs_buff()
 
 
-# test_clip
 @pytest.fixture
 def donut_geom():
     """ Fixture for donut geometry objects. """
     return make_donut_geom()
 
 
-# test_clip
 @pytest.fixture
 def multi_gdf():
     """ Create a multi-polygon GeoDataFrame. """
@@ -148,9 +142,6 @@ def test_clip_poly(locs_buff, poly_in_gdf):
     clipped_poly = cl.clip_shp(locs_buff, poly_in_gdf)
     assert len(clipped_poly.geometry) == 3
     assert clipped_poly.geom_type[1] == "Polygon"
-
-
-# TODO same test for points and lines
 
 
 def test_clip_multipoly(poly_in_gdf, multi_gdf):

--- a/earthpy/tests/test_extent_to_json.py
+++ b/earthpy/tests/test_extent_to_json.py
@@ -1,0 +1,39 @@
+""" Tests for the extent to json function """
+
+
+import pandas as pd
+import pytest
+import geopandas as gpd
+from shapely.geometry import Polygon, Point
+import earthpy.spatial as es
+
+
+def test_extent_to_json():
+    """"Unit tests for extent_to_json()."""
+    # Giving a list [minx, miny, maxx, maxy] makes a polygon
+    list_out = es.extent_to_json([0, 0, 1, 1])
+    assert list_out["type"] == "Polygon"
+
+    # The polygon is the unit square
+    list_poly = Polygon(list_out["coordinates"][0])
+    assert list_poly.area == 1
+    assert list_poly.length == 4
+
+    # Providing a GeoDataFrame creates identical output
+    points_df = pd.DataFrame({"lat": [0, 1], "lon": [0, 1]})
+    points_df["coords"] = list(zip(points_df.lon, points_df.lat))
+    points_df["coords"] = points_df["coords"].apply(Point)
+    gdf = gpd.GeoDataFrame(points_df, geometry="coords")
+    gdf_out = es.extent_to_json(gdf)
+    assert gdf_out == list_out
+
+    # Giving non-list or GeoDataFrame input raises a ValueError
+    with pytest.raises(ValueError):
+        es.extent_to_json({"a": "dict"})
+
+    # Giving minima that exceed maxima raises an error for both x and y coords
+    with pytest.raises(AssertionError):
+        es.extent_to_json([1, 0, 0, 1])
+
+    with pytest.raises(AssertionError):
+        es.extent_to_json([0, 1, 1, 0])

--- a/earthpy/tests/test_extent_to_json.py
+++ b/earthpy/tests/test_extent_to_json.py
@@ -14,6 +14,20 @@ def list_out():
     return es.extent_to_json([0, 0, 1, 1])
 
 
+@pytest.mark.parametrize(
+    "list_input,error",
+    [
+        ([1, 0, 0, 1], "xmin must be <= xmax"),
+        ([0, 1, 1, 0], "ymin must be <= ymax"),
+    ],
+)
+def test_min_exceeds_max(list_input, error):
+    """Min value that exceeds max raises error for both x and y coords"""
+
+    with pytest.raises(AssertionError, match=error):
+        es.extent_to_json(list_input)
+
+
 def test_list_format_works(list_out):
     """" Giving a list [minx, miny, maxx, maxy] makes a polygon"""
     assert list_out["type"] == "Polygon"
@@ -43,13 +57,3 @@ def test_not_a_list():
 
     with pytest.raises(ValueError):
         es.extent_to_json({"a": "dict"})
-
-
-def test_min_exceeds_max():
-    """Giving minima that exceed maxima raises error for both x and y coords"""
-
-    with pytest.raises(AssertionError):
-        es.extent_to_json([1, 0, 0, 1])
-
-    with pytest.raises(AssertionError):
-        es.extent_to_json([0, 1, 1, 0])

--- a/earthpy/tests/test_extent_to_json.py
+++ b/earthpy/tests/test_extent_to_json.py
@@ -14,13 +14,13 @@ def list_out():
     return es.extent_to_json([0, 0, 1, 1])
 
 
-def test_extent_to_json():
+def test_list_format_works():
     """" Giving a list [minx, miny, maxx, maxy] makes a polygon"""
     list_out = es.extent_to_json([0, 0, 1, 1])
     assert list_out["type"] == "Polygon"
 
 
-def test_extent_to_json(list_out):
+def test_polygon_is_square(list_out):
     """The polygon is the unit square"""
 
     list_poly = Polygon(list_out["coordinates"][0])

--- a/earthpy/tests/test_extent_to_json.py
+++ b/earthpy/tests/test_extent_to_json.py
@@ -1,4 +1,4 @@
-""" Tests for the extent to json function """
+""" Tests for the extent_to_json function """
 
 
 import pandas as pd
@@ -8,18 +8,29 @@ from shapely.geometry import Polygon, Point
 import earthpy.spatial as es
 
 
+@pytest.fixture
+def list_out():
+
+    return es.extent_to_json([0, 0, 1, 1])
+
+
 def test_extent_to_json():
-    """"Unit tests for extent_to_json()."""
-    # Giving a list [minx, miny, maxx, maxy] makes a polygon
+    """" Giving a list [minx, miny, maxx, maxy] makes a polygon"""
     list_out = es.extent_to_json([0, 0, 1, 1])
     assert list_out["type"] == "Polygon"
 
-    # The polygon is the unit square
+
+def test_extent_to_json(list_out):
+    """The polygon is the unit square"""
+
     list_poly = Polygon(list_out["coordinates"][0])
     assert list_poly.area == 1
     assert list_poly.length == 4
 
-    # Providing a GeoDataFrame creates identical output
+
+def test_gdf_format_works(list_out):
+    """ Providing a GeoDataFrame creates returns expected vals"""
+
     points_df = pd.DataFrame({"lat": [0, 1], "lon": [0, 1]})
     points_df["coords"] = list(zip(points_df.lon, points_df.lat))
     points_df["coords"] = points_df["coords"].apply(Point)
@@ -27,11 +38,17 @@ def test_extent_to_json():
     gdf_out = es.extent_to_json(gdf)
     assert gdf_out == list_out
 
-    # Giving non-list or GeoDataFrame input raises a ValueError
+
+def test_not_a_list():
+    """Providing a non-list or GeoDataFrame input raises a ValueError"""
+
     with pytest.raises(ValueError):
         es.extent_to_json({"a": "dict"})
 
-    # Giving minima that exceed maxima raises an error for both x and y coords
+
+def test_min_exceeds_max():
+    """Giving minima that exceed maxima raises error for both x and y coords"""
+
     with pytest.raises(AssertionError):
         es.extent_to_json([1, 0, 0, 1])
 

--- a/earthpy/tests/test_extent_to_json.py
+++ b/earthpy/tests/test_extent_to_json.py
@@ -10,7 +10,7 @@ import earthpy.spatial as es
 
 @pytest.fixture
 def list_out():
-
+    """ A JSON extent on the unit square spanning (0, 0), (1, 1). """
     return es.extent_to_json([0, 0, 1, 1])
 
 

--- a/earthpy/tests/test_extent_to_json.py
+++ b/earthpy/tests/test_extent_to_json.py
@@ -14,7 +14,7 @@ def list_out():
     return es.extent_to_json([0, 0, 1, 1])
 
 
-def test_list_format_works():
+def test_list_format_works(list_out):
     """" Giving a list [minx, miny, maxx, maxy] makes a polygon"""
     assert list_out["type"] == "Polygon"
 

--- a/earthpy/tests/test_extent_to_json.py
+++ b/earthpy/tests/test_extent_to_json.py
@@ -16,7 +16,6 @@ def list_out():
 
 def test_list_format_works():
     """" Giving a list [minx, miny, maxx, maxy] makes a polygon"""
-    list_out = es.extent_to_json([0, 0, 1, 1])
     assert list_out["type"] == "Polygon"
 
 

--- a/earthpy/tests/test_norm_diff.py
+++ b/earthpy/tests/test_norm_diff.py
@@ -1,0 +1,77 @@
+""" Tests for the normalized_diff function in the spatial module. """
+
+
+import numpy as np
+import numpy.ma as ma
+import pytest
+import earthpy.spatial as es
+
+
+@pytest.fixture
+def b1_b2_arrs():
+    b1 = np.array([[6, 7, 8, 9, 10], [16, 17, 18, 19, 20]])
+    b2 = np.array([[1, 2, 3, 4, 5], [14, 12, 13, 14, 17]])
+    return b1, b2
+
+
+def test_normalized_diff_shapes(b1_b2_arrs):
+    """Test that two arrays with different shapes returns a ValueError."""
+
+    # Test data
+    b1, b2 = b1_b2_arrs
+    b2 = b2[0]
+
+    # Check ValueError
+    with pytest.raises(
+        ValueError, match="Both arrays should have the same dimensions"
+    ):
+        es.normalized_diff(b1=b1, b2=b2)
+
+
+def test_normalized_diff_no_mask(b1_b2_arrs):
+    """Test that if result does not include nan values,
+    the array is returned as unmasked."""
+
+    # Test data
+    b1, b2 = b1_b2_arrs
+
+    n_diff = es.normalized_diff(b1=b1, b2=b2)
+
+    # Output array unmasked
+    assert not ma.is_masked(n_diff)
+
+
+def test_normalized_diff_inf(b1_b2_arrs):
+    """Test that inf values in result are set to nan and
+    that array is returned as masked."""
+
+    # Test data
+    b1, b2 = b1_b2_arrs
+    b2[1:, 4:] = -20
+
+    # Check warning
+    with pytest.warns(
+        Warning, match="Divide by zero produced infinity values"
+    ):
+        n_diff = es.normalized_diff(b1=b1, b2=b2)
+
+    # Inf values set to nan
+    assert not np.isinf(n_diff).any()
+
+    # Output array masked
+    assert ma.is_masked(n_diff)
+
+
+def test_normalized_diff_mask(b1_b2_arrs):
+    """Test that if result does include nan values,
+    the array is returned as masked."""
+
+    # Test data
+    b1, b2 = b1_b2_arrs
+    b2 = b2.astype(float)
+    b2[1:, 4:] = np.nan
+
+    n_diff = es.normalized_diff(b1=b1, b2=b2)
+
+    # Output array masked
+    assert ma.is_masked(n_diff)

--- a/earthpy/tests/test_plot_bands.py
+++ b/earthpy/tests/test_plot_bands.py
@@ -8,6 +8,15 @@ import numpy as np
 plt.show = lambda: None
 
 
+@pytest.fixture
+def one_band_3dims():
+    """Return a 3-dim numpy array vals 0-9"""
+
+    return np.array(
+        [[[8, 0, 2, 6, 3], [2, 8, 2, 8, 4], [3, 9, 1, 5, 4], [5, 9, 2, 7, 7]]]
+    )
+
+
 def test_arr_parameter():
     """Raise an AttributeError if an array is not provided."""
     with pytest.raises(

--- a/earthpy/tests/test_stack.py
+++ b/earthpy/tests/test_stack.py
@@ -82,3 +82,13 @@ def test_stack_nodata_outfile(in_paths, out_path):
     # basic_image has 91 0 values, which should be masked
     assert 0 not in stack_arr and np.sum(stack_arr.mask) == 91 * len(in_paths)
     assert os.path.exists(out_path)
+
+
+def test_stack_invalid_out_paths_raise_errors():
+    """ If users provide an output path that doesn't exist, raise error. """
+
+    with pytest.raises(ValueError, match="not exist"):
+        es.stack(
+            band_paths=["fname1.tif", "fname2.tif"],
+            out_path="nonexistent_directory/output.tif",
+        )


### PR DESCRIPTION
This PR addresses https://github.com/earthlab/earthpy/issues/219  and #218 
it includes:
1. cleanup of `conftest.py` file to ensure only fixtures used across multiple functions are included
2. splitting up the `test_spatial.py` file into function specific test files.

In this cleanup process, i noticed that the extent_to_json() function has ALL TESTS in one giant function. So that is cleaned up as well.