### PR TITLE
Another bug fix in plot rgb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+* Fix bug in plot_rgb where multipanel plots are blank (@lwasser, #313)
+
 ## [0.6.7]
 * Add NoData masking support for `stack()` (@joemcglinchy, #282)
 * Fix multiline messages to use `"` vs `"""` (@lwasser, #270)

--- a/earthpy/plot.py
+++ b/earthpy/plot.py
@@ -323,12 +323,17 @@ def plot_rgb(
     # Then plot. Define ax if it's default to none
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
+        ax.imshow(rgb_bands, extent=extent)
+        ax.set_title(title)
+        ax.set(xticks=[], yticks=[])
+        # Multipanel won't work if plt.show is called prior to second plot def
+        # Thus we either have redundant code or DON"T call plt.show
+        plt.show()
     else:
-        fig = None
-    ax.imshow(rgb_bands, extent=extent)
-    ax.set_title(title)
-    ax.set(xticks=[], yticks=[])
-    plt.show()
+        # fig = None
+        ax.imshow(rgb_bands, extent=extent)
+        ax.set_title(title)
+        ax.set(xticks=[], yticks=[])
     return ax
 
 

--- a/earthpy/plot.py
+++ b/earthpy/plot.py
@@ -320,20 +320,19 @@ def plot_rgb(
         # Index bands for plotting and clean up data for matplotlib
         rgb_bands = es.bytescale(rgb_bands).transpose([1, 2, 0])
 
-    # Then plot. Define ax if it's default to none
+    # Then plot. Define ax if it's undefined
+    show = False
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-        ax.imshow(rgb_bands, extent=extent)
-        ax.set_title(title)
-        ax.set(xticks=[], yticks=[])
-        # Multipanel won't work if plt.show is called prior to second plot def
-        # Thus we either have redundant code or DON"T call plt.show
+        show = True
+
+    ax.imshow(rgb_bands, extent=extent)
+    ax.set_title(title)
+    ax.set(xticks=[], yticks=[])
+
+    # Multipanel won't work if plt.show is called prior to second plot def
+    if show:
         plt.show()
-    else:
-        # fig = None
-        ax.imshow(rgb_bands, extent=extent)
-        ax.set_title(title)
-        ax.set(xticks=[], yticks=[])
     return ax
 
 

--- a/earthpy/tests/test_plot_rgb.py
+++ b/earthpy/tests/test_plot_rgb.py
@@ -86,6 +86,27 @@ def test_ax_provided(rgb_image):
     plt.close()
 
 
+def test_two_ax_provided(rgb_image):
+    """Test to ensure the plot works when more than one axis is provided
+
+    This test is being added because it turned out that the second plot
+    was clearing given a call to plt.show and that wasn't being captured
+    in the previous tests. """
+
+    rgb_image, _ = rgb_image
+    f, (ax1, ax2) = plt.subplots(2, 1)
+    ax1_test = plot_rgb(rgb_image, ax=ax1)
+    ax2_test = plot_rgb(rgb_image, ax=ax2)
+
+    rgb_im_shape = rgb_image.transpose([1, 2, 0]).shape
+    the_plot_im_shape = ax1_test.get_images()[0].get_array().shape
+    the_plot_im_shape2 = ax2_test.get_images()[0].get_array().shape
+
+    assert rgb_im_shape == the_plot_im_shape
+    assert rgb_im_shape == the_plot_im_shape2
+    plt.close()
+
+
 def test_ax_not_provided(rgb_image):
     """Test plot_rgb produces an output image when an axis object is
     not provided."""


### PR DESCRIPTION
well it turns out that i missed yet another bug in plot_rgb.

This fix addresses the issue that when you attempt to create a multi-panel plot, this function was plotting the FIRST plot and the rest of the panels were empty. This was because we decided to add `plt.show()` to the function call.

@mbjoseph  when you look at this PR you'll notice there is now some redundant code in the last statement where the plot is generated. 

If we don't want that code, we need to 

1. drop the `plt.show()` call altogether. 

i could be convinced to do this given the function returns the ax object which "prints" as a returned item. or we leave it nice and clean and it just plots for the user by default UNLESS they are creating a more involved plot. 

Note that in this i'm adding a second test that tests a multi panel setup . i was testing only ONE axis previously which was passing just fine but failing upon addding the second axis (which was empty!!).