### PR TITLE
Zenodo update -- creator vs contributor

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,7 +24,9 @@
       "affiliation": "Berkeley Institute for Data Science, UC Berkeley",
       "name": "Holdgraf, Chris",
       "orcid": "0000-0002-2391-0678"
-    },
+    }
+  ],
+  "contributors": [
     {
       "affiliation": "Wild Tree Tech",
       "name": "Head, Tim",


### PR DESCRIPTION
Creating a distinction between "Creators" and "contributors"