### PR TITLE
pandas is a redundant requirement for earthpy

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 bumpversion==0.5.3
 codecov
 m2r==0.2.1
-pandas
 pre-commit==1.17.0
 pytest
 pytest-cov


### PR DESCRIPTION
geopandas should install pandas but also pandas is a part of anaconda.

this should address #358 