### PR TITLE
fix appveyor fail by installing earthpy without the deps

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda env create -f environment.yml
   - activate earthpy-dev
-  - python setup.py install
+  - pip install -e . --no-deps
   - pip install -r dev-requirements.txt
 
 test_script:


### PR DESCRIPTION
Essentially this happened for matplotcheck as well. Because earthpy is installing locally via python, it tries to reinstall all of the dependencies. this causes issues. but all of those deps are in our envt so it's unneccesary. installing via pip without the dependencies should make appveyor happy.