### PR TITLE
Add requests to setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
             "rasterio",
             "Rtree>=0.8",
             "scikit-image",
+            "requests",
         ],
         zip_safe=False,  # the package can run out of an .egg file
         classifiers=[


### PR DESCRIPTION
It's imported by earthpy.io but not specified in the setup script, so `pip install earthpy` in a new fresh python environment doesn't quite work. This PR takes care of that.