### PR TITLE
fix black and also badge order on readme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://github.com/ambv/black
+- repo: https://github.com/psf/black
   rev: stable
   hooks:
   - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - os: linux
           dist: xenial
           python: 3.7
-          env: TOXENV=py37,black,docs
+          env: TOXENV=py37 #,black,docs
         - os: osx
           language: generic
 
@@ -24,6 +24,9 @@ install:
 script:
   - chmod +x .travis/test.sh
   - ./.travis/test.sh
+
+after_failure:
+  - cat MSBuild_*.failure.txt
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - os: linux
           dist: xenial
           python: 3.7
-          env: TOXENV=py37,black #,docs
+          env: TOXENV=py37, black ,docs
         - os: osx
           language: generic
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - ./.travis/test.sh
 
 after_failure:
-  - cat MSBuild_*.failure.txt
+  - cat /home/travis/build/earthlab/earthpy/.tox/black/log/black-2.log
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - os: linux
           dist: xenial
           python: 3.7
-          env: TOXENV=py37 #,black,docs
+          env: TOXENV=py37,black #,docs
         - os: osx
           language: generic
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![DOI](https://zenodo.org/badge/122149160.svg)](https://zenodo.org/badge/latestdoi/122149160)
+[![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/12)
 [![Build Status](https://travis-ci.org/earthlab/earthpy.svg?branch=master)](https://travis-ci.org/earthlab/earthpy)
 [![Build status](https://ci.appveyor.com/api/projects/status/xgf5g4ms8qhgtp21?svg=true)](https://ci.appveyor.com/project/earthlab/earthpy)
 [![codecov](https://codecov.io/gh/earthlab/earthpy/branch/master/graph/badge.svg)](https://codecov.io/gh/earthlab/earthpy)
@@ -8,12 +9,11 @@
 # EarthPy
 
 ![PyPI](https://img.shields.io/pypi/v/earthpy.svg?color=purple&style=plastic)
-[![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/12)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/earthpy.svg?color=purple&label=pypi%20downloads&style=plastic)
 ![Conda](https://img.shields.io/conda/v/conda-forge/earthpy.svg?color=purple&style=plastic)
 ![Conda](https://img.shields.io/conda/dn/conda-forge/earthpy.svg?color=purple&label=conda-forge%20downloads&style=plastic)
 
-EarthPy is makes it easier to plot and manipulate spatial data in Python.
+EarthPy makes it easier to plot and manipulate spatial data in Python.
 
 ## Why EarthPy?
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ sphinx-autobuild==0.7.1
 sphinx_gallery==0.4.0
 sphinx_rtd_theme==0.4.3
 tox==3.13.2
+pip>=19.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ commands =
 
 [testenv:black]
 deps =
-  pip>=19.0, black
+  pip>=19.0
+  black
 basepython = python3
 commands = black --check --verbose earthpy
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,10 @@ commands =
 [testenv:black]
 deps = black
 basepython = python3
+#deps =
+#    -r{toxinidir}/dev-requirements.txt
 deps =
-    -r{toxinidir}/dev-requirements.txt
+    pip>=19.0
 commands = black --check --verbose earthpy
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ commands =
 [testenv:black]
 deps = black
 basepython = python3
+deps =
+    -r{toxinidir}/dev-requirements.txt
 commands = black --check --verbose earthpy
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -17,12 +17,9 @@ commands =
     codecov -e TOXENV
 
 [testenv:black]
-deps = black
-basepython = python3
-#deps =
-#    -r{toxinidir}/dev-requirements.txt
 deps =
-    pip>=19.0
+  pip>=19.0, black
+basepython = python3
 commands = black --check --verbose earthpy
 
 [testenv:docs]


### PR DESCRIPTION
ok a few notes on this pr
it was supposed to be a simple update but it turns out that there are some issues with pyproj which needs pip>= 19.0 to install properly. as a fix i adjust the deps to specify the min version of pip and also adjusted the tox envt for black to ensure pip was being used to install earthpy.

Just a note that this setup actually seems a bit redundant to me as in the tox envt earthpy is being installed aGAIN from what i can see. i suspect we could make our build faster by just running black in the main earthpy py 3.7 build... but for now i'm just fixing things