### PR TITLE
Suggested updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![DOI](https://zenodo.org/badge/122149160.svg)](https://zenodo.org/badge/latestdoi/122149160)
-[![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/12)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.01886/status.svg)](https://doi.org/10.21105/joss.01886)
+[![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/12)
 [![Build Status](https://travis-ci.org/earthlab/earthpy.svg?branch=master)](https://travis-ci.org/earthlab/earthpy)
 [![Build status](https://ci.appveyor.com/api/projects/status/xgf5g4ms8qhgtp21?svg=true)](https://ci.appveyor.com/project/earthlab/earthpy)
 [![codecov](https://codecov.io/gh/earthlab/earthpy/branch/master/graph/badge.svg)](https://codecov.io/gh/earthlab/earthpy)
@@ -127,6 +126,25 @@ for more information about submitting pull requests or changes to EarthPy.
 [BSD-3](https://github.com/earthlab/earthpy/blob/master/LICENSE)
 
 ### Citation Information
-EarthPy citation information can be found on [zenodo](https://zenodo.org/record/2573233/export/hx). A link to bibtext format is below:
 
-*[bibtex](https://zenodo.org/record/2573233/export/hx)
+When citing EarthPy, please cite our [JOSS paper](https://doi.org/10.21105/joss.01886):
+
+```
+@article{Wasser2019EarthPy,
+	journal = {Journal of Open Source Software},
+	doi = {10.21105/joss.01886},
+	issn = {2475-9066},
+	number = {43},
+	publisher = {The Open Journal},
+	title = {EarthPy: A Python package that makes it easier to explore and plot raster and vector data using open source Python tools.},
+	url = {https://doi.org/10.21105/joss.01886},
+	volume = {4},
+	author = {Wasser, Leah and Joseph, Maxwell and McGlinchy, Joe and Palomino, Jenny and Korinek, Nathan and Holdgraf, Chris and Head, Tim},
+	pages = {1886},
+	date = {2019-11-13},
+	year = {2019},
+	month = {11},
+	day = {13},
+}
+
+```


### PR DESCRIPTION
:wave: @lwasser - this PR does two things:

1. Updates the preferred citation for the package to link to the JOSS paper.
2. Removes the Zenodo DOI badge - rationale that this is likely to cause confusion to users, especially if you want to encourage citation of the paper rather than a Zenodo DOI?