### PR TITLE
fix clip vignette - remove empty geoms

### DIFF
--- a/examples/plot_clip.py
+++ b/examples/plot_clip.py
@@ -114,6 +114,8 @@ plt.show()
 # of the object that is being clipped (e.g. roads).
 
 roads_clipped = ec.clip_shp(roads, country_boundary)
+# Remove empty geometries
+roads_clipped = roads_clipped[~roads_clipped.is_empty]
 
 # Plot the clipped data
 # The plot below shows the results of the clip function applied to the roads


### PR DESCRIPTION
I am not sure how this has been passing all of this time but this PR fixes the vignette that's breaking everything. When there are empty geometries things go bonkers and plotting breaks. Fix is using `is_emtpy`. easy enough! Come on travis, be a happy little CI robot. 
this addresses #475 