### PR TITLE
BUG FIX: fix twitter-flood data key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Fix twitter flood data key in get_data (@lwasser, #512)
 * Fix clip vignette. Cant plot w empty geoms (@lwasser, #475)
 
 ## [0.8]
-* JOSS paper and pyopensci review completed release! 
+* JOSS paper and pyopensci review completed release!
 
 ## [0.7.6]
 * no significant changes but pyopensci approval and badge added.

--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -80,11 +80,13 @@ DATA_URLS = {
         ".",
         "zip",
     ),
-    "twitter-flood": (
-        "https://ndownloader.figshare.com/files/10960175",
-        ".",
-        "zip",
-    ),
+    "twitter-flood": [
+        (
+            "https://ndownloader.figshare.com/files/10960175",
+            "boulder_flood_geolocated_tweets.json",
+            "file",
+        )
+    ],
 }
 
 HOME = op.join(op.expanduser("~"))


### PR DESCRIPTION
This pr addresses #512 which specifically relates to twitter data. since the data are not zipped they needed to be entered into earthpy differently to ensure they were downloaded as files. 