### PR TITLE
update docstring for crop_image

### DIFF
--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -338,7 +338,7 @@ def crop_image(raster, geoms, all_touched=True):
 
     Parameters
     ----------
-    raster : rasterio object
+    raster : rasterio.io.DatasetReader object
         The rasterio object to be cropped.
     geoms : geopandas geodataframe or list of polygons
         The spatial polygon boundaries in GeoJSON-like dict format
@@ -369,13 +369,13 @@ def crop_image(raster, geoms, all_touched=True):
         >>> from earthpy.io import path_to_example
         >>> # Clip an RGB image to the extent of Rocky Mountain National Park
         >>> rmnp = gpd.read_file(path_to_example("rmnp.shp"))
-        >>> with rio.open(path_to_example("rmnp-rgb.tif")) as raster:
-        ...     src_image = raster.read()
-        ...     out_image, out_meta = es.crop_image(raster, rmnp)
+        >>> with rio.open(path_to_example("rmnp-rgb.tif")) as src:
+        ...     in_image = src.read()
+        ...     out_image, out_meta = es.crop_image(src, rmnp)
+        >>> in_image.shape
+        (3, 373, 485)
         >>> out_image.shape
         (3, 265, 281)
-        >>> src_image.shape
-        (3, 373, 485)
     """
     if isinstance(geoms, gpd.geodataframe.GeoDataFrame):
         clip_extent = [extent_to_json(geoms)]

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -371,9 +371,9 @@ def crop_image(raster, geoms, all_touched=True):
         >>> rmnp = gpd.read_file(path_to_example("rmnp.shp"))
         >>> with rio.open(path_to_example("rmnp-rgb.tif")) as src_raster:
         ...     cropped_raster, cropped_meta = es.crop_image(src_raster, rmnp)
-        >>> src_raster.shape[1:3]
+        >>> src_raster.shape
         (373, 485)
-        >>> cropped_raster.shape
+        >>> cropped_raster.shape[1:3]
         (265, 281)
     """
     if isinstance(geoms, gpd.geodataframe.GeoDataFrame):

--- a/earthpy/spatial.py
+++ b/earthpy/spatial.py
@@ -369,13 +369,12 @@ def crop_image(raster, geoms, all_touched=True):
         >>> from earthpy.io import path_to_example
         >>> # Clip an RGB image to the extent of Rocky Mountain National Park
         >>> rmnp = gpd.read_file(path_to_example("rmnp.shp"))
-        >>> with rio.open(path_to_example("rmnp-rgb.tif")) as src:
-        ...     in_image = src.read()
-        ...     out_image, out_meta = es.crop_image(src, rmnp)
-        >>> in_image.shape
-        (3, 373, 485)
-        >>> out_image.shape
-        (3, 265, 281)
+        >>> with rio.open(path_to_example("rmnp-rgb.tif")) as src_raster:
+        ...     cropped_raster, cropped_meta = es.crop_image(src_raster, rmnp)
+        >>> src_raster.shape[1:3]
+        (373, 485)
+        >>> cropped_raster.shape
+        (265, 281)
     """
     if isinstance(geoms, gpd.geodataframe.GeoDataFrame):
         clip_extent = [extent_to_json(geoms)]


### PR DESCRIPTION
Addresses #483 to improve docstring for `spatial.crop_image()`. Changes:

1. changes description of raster input parameter from `a raster object` to `a rasterio.io.DatasetReader object` to be more accurate

2. While the initial issue requested removal of line 373(`src_image = raster.read()`) followed by retrieval of the `shape` attribute directly from the `raster` object, this does not produce the expected output. `raster` is of type `rasterio.io.DatasetReader` and the `shape` attribute does not return the number of bands present in the dataset (returns `(373, 485)`, but expects `(3, 373, 485)`. For now I've left line 373 in, but changed the names of variables in the vignette to be consistent with other vignettes in `earthpy` and a bit more descriptive:

    `raster` --> `src` : this matches other docstring vignettes e.g., `hillshade`
    `src_image` --> `in_image` : follows `out_image` naming of the cropped raster

    I also reordered the calls to `shape` as it seemed more logical to print the input first followed by output for comparison.

`make docs` ran successfully so it should be good to go barring any objections! Glad to take any feedback.