### PR TITLE
Fix Linting tests

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -37,7 +37,7 @@ jobs:
         make docs -B
     - name: Run Black
       run: |
-        flake8 earthpy
+        black earthpy
     - name: Run Flake8
       run: |
         flake8 earthpy


### PR DESCRIPTION
Fixed Linting tests to run both black and flake8 instead of running flake8 twice. Resolving [issue #714](https://github.com/earthlab/earthpy/issues/714). @lwasser @nkorinek 