### PR TITLE
Install EarthPy on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Below is a quick example of plotting multiple bands in a numpy array format.
 >>> plt.show()
 ```
 
+### Install on Fedora
+
+To install EarthPy on Fedora, use:
+
+```bash
+$ dnf install python3-earthpy
+```
+
 ## Active Maintainers
 
 We welcome contributions to EarthPy. Below are the current active package maintainers. Please see our


### PR DESCRIPTION
## Description

EarthPy is now available also as a rpm package for Fedora Linux.  Users can install this package using dnf or yum package managers.

