### PR TITLE
Fix plot_rgb stretch for masked arrays

### DIFF
--- a/earthpy/plot.py
+++ b/earthpy/plot.py
@@ -331,7 +331,10 @@ def _stretch_im(arr, str_clip):
     s_max = 100 - str_clip
     arr_rescaled = np.zeros_like(arr)
     for ii, band in enumerate(arr):
-        lower, upper = np.nanpercentile(band, (s_min, s_max))
+        if np.ma.isMaskedArray(band):
+            lower, upper = np.nanpercentile(band.compressed(), (s_min, s_max))
+        else:
+            lower, upper = np.nanpercentile(band, (s_min, s_max))
         arr_rescaled[ii] = exposure.rescale_intensity(
             band, in_range=(lower, upper)
         )


### PR DESCRIPTION
Fixes Issue # 675

I have tested it with Landsat vignette datasets and it stretches masked bands correctly. 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked my code and corrected any misspellings
