### PR TITLE
Fix plot_rgb stretch failure with masked NaN arrays

### DIFF
--- a/earthpy/io.py
+++ b/earthpy/io.py
@@ -18,6 +18,12 @@ from .config import DEFAULT_DATA_HOME, DATA_URLS, FIGSHARE_API_URL, DVCIGNORE
 
 ALLOWED_FILE_TYPES = ["file", "tar", "tar.gz", "zip"]
 
+EXAMPLE_DATA = pathlib.Path(__file__).parent / "example-data"
+
+def path_to_example(filename):
+    """Return the full path to an example data file."""
+    return str(EXAMPLE_DATA / filename)
+
 # Backward compatibility for old datasets
 HOME = pathlib.Path.home()
         

--- a/earthpy/plot.py
+++ b/earthpy/plot.py
@@ -331,7 +331,10 @@ def _stretch_im(arr, str_clip):
     s_max = 100 - str_clip
     arr_rescaled = np.zeros_like(arr)
     for ii, band in enumerate(arr):
-        lower, upper = np.nanpercentile(band, (s_min, s_max))
+        if ma.is_masked(band):
+            lower, upper = np.percentile(band.compressed(), (s_min, s_max))
+        else:
+            lower, upper = np.nanpercentile(band, (s_min, s_max))
         arr_rescaled[ii] = exposure.rescale_intensity(
             band, in_range=(lower, upper)
         )


### PR DESCRIPTION
**IMPORTANT: DO NOT USE THIS REPO TO PRACTICE PULL REQUESTS AND LEARN GITHUB!** 

# Earth Lab -- Pull Request Template
Welcome to EarthPy! 

Before submitting a Pull Request please be sure to submit an issue that describes what the contents of the PR addresses.

**IMPORTANT:** Please do not use this repository as a practice activity to learn how to use GitHub! Only submit a PR after: 

1. Submitting an issue with a valid item that you wish to address in earthpy
2. Getting approval from one of the maintainers to submit a formal PR.

## Description

 Fixes #675

  _stretch_im() uses np.nanpercentile() which does not handle masked arrays correctly.
  When a band is a masked array (e.g., raster loaded by rioxarray), it returns NaN
  values, causing rescale_intensity to produce a black image.

  Added a check: if band is masked, use np.percentile(band.compressed(), ...) instead.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

 ## Testing

  ### Test A - Existing test suite
  python -m pytest earthpy/tests/test_plot_rgb.py -v
  All 12 tests passed, including `test_stretch_image_nan` and `test_masked_im`.
  No regressions.

  ### Test B - Reproduction of issue #675
  ```python
  import matplotlib
  matplotlib.use('Agg')
  import earthpy.plot as ep
  import numpy as np

  r = [[128,  64, np.nan], [128,   0,   0], [  0, 128, 128]]
  g = [[128,  64, np.nan], [  0, 128,   0], [128,   0, 128]]
  b = [[128,  64, np.nan], [  0,   0, 128], [128, 128,   0]]
  arr = np.array([r, g, b])

  arr_nan_masked = np.ma.masked_invalid(arr)
  ax = ep.plot_rgb(arr_nan_masked, rgb=(2, 1, 0), stretch=True)
  img = ax.get_images()[0].get_array()
  assert img.max() > 10, "Image should not be all black"
  print("PASSED: image min=%.1f max=%.1f" % (img.min(), img.max()))
  Previously returned a black image. Now renders correctly (min=0.0, max=255.0).

  Test configuration

  - OS: Windows 11
  - Python: 3.11.9
  - Key dependencies: numpy, matplotlib, scikit-image, rasterio


## Checklist:

- [ ] I have already submitted an issue and it was approved for a pr by an earthpy maintainer
- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x ] I have checked my code and corrected any misspellings
